### PR TITLE
Replace leaky in-memory session store

### DIFF
--- a/app/server/authSetup.js
+++ b/app/server/authSetup.js
@@ -1,9 +1,12 @@
 import passport from 'passport';
 import { Strategy as GoogleStrategy } from 'passport-google-oauth20';
-import session from 'express-session';
+import cookieSession from 'cookie-session';
 
 export const authSetup = app => {
-  app.use(session({ secret: process.env.SESSION_SECRET, resave: true, saveUninitialized: true }));
+  app.use(cookieSession({
+    secret: process.env.SESSION_SECRET,
+  }));
+
   app.use(passport.initialize());
   app.use(passport.session());
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "babel-register": "^6.7.2",
     "babel-runtime": "^6.6.1",
     "body-parser": "^1.15.1",
+    "cookie-session": "^2.0.0-alpha.1",
     "dotenv": "^2.0.0",
     "es6-promise": "^3.1.2",
     "eslint": "^2.11.1",


### PR DESCRIPTION
When starting the app with the existing in memory session we get a warning saying that it should not be used in production like this as it leaks memory, so I've swapped it out for regular cookie based sessions.

It also allows us to use multiple app instances without losing session, but I doubt we'll ever need it.