### PR TITLE
Load initial editor state from server

### DIFF
--- a/app/actions/community_events.js
+++ b/app/actions/community_events.js
@@ -1,17 +1,9 @@
 export const UPDATE_EVENT = 'UPDATE_EVENT';
-export const SET_EVENTS = 'SET_EVENTS';
 
 export function updateEvent(eventID, event) {
   return {
     type: UPDATE_EVENT,
     eventID,
     event,
-  };
-}
-
-export function setEvents(events) {
-  return {
-    type: SET_EVENTS,
-    events,
   };
 }

--- a/app/actions/persistence.js
+++ b/app/actions/persistence.js
@@ -11,6 +11,7 @@ export function stateLoaded({ community, conference, events }) {
 }
 
 export function stateLoadFailed(error) {
+  console.error('Failed to load state.', error);
   return {
     type: STATE_LOAD_FAILED,
     error,

--- a/app/actions/persistence.js
+++ b/app/actions/persistence.js
@@ -1,0 +1,18 @@
+export const STATE_LOADED = 'STATE_LOADED';
+export const STATE_LOAD_FAILED = 'STATE_LOAD_FAILED';
+
+export function stateLoaded({ community, conference, events }) {
+  return {
+    type: STATE_LOADED,
+    community,
+    conference,
+    events,
+  };
+}
+
+export function stateLoadFailed(error) {
+  return {
+    type: STATE_LOAD_FAILED,
+    error,
+  };
+}

--- a/app/actions/persistence.js
+++ b/app/actions/persistence.js
@@ -11,7 +11,6 @@ export function stateLoaded({ community, conference, events }) {
 }
 
 export function stateLoadFailed(error) {
-  console.error('Failed to load state.', error);
   return {
     type: STATE_LOAD_FAILED,
     error,

--- a/app/actions/persistence.js
+++ b/app/actions/persistence.js
@@ -1,16 +1,16 @@
-export const STATE_LOADED = 'STATE_LOADED';
+export const SITE_STATE_LOADED = 'SITE_STATE_LOADED';
 export const STATE_LOAD_FAILED = 'STATE_LOAD_FAILED';
 
-export function stateLoaded({ community, conference, events }) {
+export function siteStateLoaded({ community, conference, events }) {
   return {
-    type: STATE_LOADED,
+    type: SITE_STATE_LOADED,
     community,
     conference,
     events,
   };
 }
 
-export function stateLoadFailed(error) {
+export function siteStateLoadFailed(error) {
   return {
     type: STATE_LOAD_FAILED,
     error,

--- a/app/api.js
+++ b/app/api.js
@@ -4,5 +4,6 @@ export function fetchSiteState() {
   return fetch(SITE_ENDPOINT, {
     credentials: 'same-origin',
   })
-  .then(response => response.json());
+  .then(response => response.json())
+  .catch(error => { throw error; });
 }

--- a/app/api.js
+++ b/app/api.js
@@ -1,0 +1,9 @@
+const INITIAL_STATE = '/api/state';
+
+export function fetchInitialState() {
+  return fetch(INITIAL_STATE, {
+    credentials: 'same-origin',
+  })
+  .then(response => response.json()
+  .then(json => json.data));
+}

--- a/app/api.js
+++ b/app/api.js
@@ -1,9 +1,8 @@
-const INITIAL_STATE = '/api/state';
+const SITE_ENDPOINT = '/site';
 
-export function fetchInitialState() {
-  return fetch(INITIAL_STATE, {
+export function fetchSiteState() {
+  return fetch(SITE_ENDPOINT, {
     credentials: 'same-origin',
   })
-  .then(response => response.json()
-  .then(json => json.data));
+  .then(response => response.json());
 }

--- a/app/reducers/community/index.js
+++ b/app/reducers/community/index.js
@@ -1,8 +1,8 @@
-import { STATE_LOADED } from '../../actions/persistence';
+import { SITE_STATE_LOADED } from '../../actions/persistence';
 
 export default function community(state = {}, action) {
   switch (action.type) {
-    case STATE_LOADED:
+    case SITE_STATE_LOADED:
       return action.community;
 
     default:

--- a/app/reducers/community/index.js
+++ b/app/reducers/community/index.js
@@ -1,0 +1,11 @@
+import { STATE_LOADED } from '../../actions/persistence';
+
+export default function community(state = {}, action) {
+  switch (action.type) {
+    case STATE_LOADED:
+      return action.community;
+
+    default:
+      return state;
+  }
+}

--- a/app/reducers/community/test.js
+++ b/app/reducers/community/test.js
@@ -1,6 +1,6 @@
 import deepFreeze from 'deep-freeze';
 import reducer from '.';
-import { stateLoaded } from '../../actions/persistence';
+import { siteStateLoaded } from '../../actions/persistence';
 
 describe('events reducer', () => {
   it('has default state', () => {
@@ -13,7 +13,7 @@ describe('events reducer', () => {
     it('adds the event when the ID is new', () => {
       const prev = deepFreeze({ foo: 15 });
       const community = { foo: 1, bar: 2 };
-      const action = stateLoaded({ community });
+      const action = siteStateLoaded({ community });
       const state = reducer(prev, action);
       expect(state).to.deep.equal({ foo: 1, bar: 2 });
     });

--- a/app/reducers/community/test.js
+++ b/app/reducers/community/test.js
@@ -1,0 +1,21 @@
+import deepFreeze from 'deep-freeze';
+import reducer from '.';
+import { stateLoaded } from '../../actions/persistence';
+
+describe('events reducer', () => {
+  it('has default state', () => {
+    const prev = deepFreeze({});
+    const state = reducer(undefined, prev);
+    expect(state).to.deep.equal({});
+  });
+
+  describe('STATE_LOADED handling', () => {
+    it('adds the event when the ID is new', () => {
+      const prev = deepFreeze({ 5: { title: 'React London 5' } });
+      const community = { foo: 1, bar: 2 };
+      const action = stateLoaded({ community });
+      const state = reducer(prev, action);
+      expect(state).to.deep.equal({ foo: 1, bar: 2 });
+    });
+  });
+});

--- a/app/reducers/community/test.js
+++ b/app/reducers/community/test.js
@@ -9,8 +9,8 @@ describe('events reducer', () => {
     expect(state).to.deep.equal({});
   });
 
-  describe('STATE_LOADED handling', () => {
-    it('adds the event when the ID is new', () => {
+  describe('SITE_STATE_LOADED handling', () => {
+    it('overwrites the state', () => {
       const prev = deepFreeze({ foo: 15 });
       const community = { foo: 1, bar: 2 };
       const action = siteStateLoaded({ community });

--- a/app/reducers/conference/index.js
+++ b/app/reducers/conference/index.js
@@ -1,0 +1,11 @@
+import { STATE_LOADED } from '../../actions/persistence';
+
+export default function conference(state = {}, action) {
+  switch (action.type) {
+    case STATE_LOADED:
+      return action.conference;
+
+    default:
+      return state;
+  }
+}

--- a/app/reducers/conference/index.js
+++ b/app/reducers/conference/index.js
@@ -1,8 +1,8 @@
-import { STATE_LOADED } from '../../actions/persistence';
+import { SITE_STATE_LOADED } from '../../actions/persistence';
 
 export default function conference(state = {}, action) {
   switch (action.type) {
-    case STATE_LOADED:
+    case SITE_STATE_LOADED:
       return action.conference;
 
     default:

--- a/app/reducers/conference/test.js
+++ b/app/reducers/conference/test.js
@@ -9,8 +9,8 @@ describe('events reducer', () => {
     expect(state).to.deep.equal({});
   });
 
-  describe('STATE_LOADED handling', () => {
-    it('adds the event when the ID is new', () => {
+  describe('SITE_STATE_LOADED handling', () => {
+    it('overwrites the state', () => {
       const prev = deepFreeze({ title: 'React London 5' });
       const conference = { title: 'Elm' };
       const action = siteStateLoaded({ conference });

--- a/app/reducers/conference/test.js
+++ b/app/reducers/conference/test.js
@@ -1,6 +1,6 @@
 import deepFreeze from 'deep-freeze';
 import reducer from '.';
-import { stateLoaded } from '../../actions/persistence';
+import { siteStateLoaded } from '../../actions/persistence';
 
 describe('events reducer', () => {
   it('has default state', () => {
@@ -13,7 +13,7 @@ describe('events reducer', () => {
     it('adds the event when the ID is new', () => {
       const prev = deepFreeze({ title: 'React London 5' });
       const conference = { title: 'Elm' };
-      const action = stateLoaded({ conference });
+      const action = siteStateLoaded({ conference });
       const state = reducer(prev, action);
       expect(state).to.deep.equal({ title: 'Elm' });
     });

--- a/app/reducers/conference/test.js
+++ b/app/reducers/conference/test.js
@@ -11,11 +11,11 @@ describe('events reducer', () => {
 
   describe('STATE_LOADED handling', () => {
     it('adds the event when the ID is new', () => {
-      const prev = deepFreeze({ foo: 15 });
-      const community = { foo: 1, bar: 2 };
-      const action = stateLoaded({ community });
+      const prev = deepFreeze({ title: 'React London 5' });
+      const conference = { title: 'Elm' };
+      const action = stateLoaded({ conference });
       const state = reducer(prev, action);
-      expect(state).to.deep.equal({ foo: 1, bar: 2 });
+      expect(state).to.deep.equal({ title: 'Elm' });
     });
   });
 });

--- a/app/reducers/events/index.js
+++ b/app/reducers/events/index.js
@@ -1,5 +1,5 @@
 import { SET_EVENTS, UPDATE_EVENT } from '../../actions/community_events';
-import { STATE_LOADED } from '../../actions/persistence';
+import { SITE_STATE_LOADED } from '../../actions/persistence';
 
 export default function events(state = {}, action) {
   switch (action.type) {
@@ -12,7 +12,7 @@ export default function events(state = {}, action) {
     case SET_EVENTS:
       return action.events;
 
-    case STATE_LOADED:
+    case SITE_STATE_LOADED:
       return action.events;
 
     default:

--- a/app/reducers/events/index.js
+++ b/app/reducers/events/index.js
@@ -1,4 +1,5 @@
 import { SET_EVENTS, UPDATE_EVENT } from '../../actions/community_events';
+import { STATE_LOADED } from '../../actions/persistence';
 
 export default function events(state = {}, action) {
   switch (action.type) {
@@ -9,6 +10,9 @@ export default function events(state = {}, action) {
       };
 
     case SET_EVENTS:
+      return action.events;
+
+    case STATE_LOADED:
       return action.events;
 
     default:

--- a/app/reducers/events/index.js
+++ b/app/reducers/events/index.js
@@ -1,4 +1,4 @@
-import { SET_EVENTS, UPDATE_EVENT } from '../../actions/community_events';
+import { UPDATE_EVENT } from '../../actions/community_events';
 import { SITE_STATE_LOADED } from '../../actions/persistence';
 
 export default function events(state = {}, action) {
@@ -8,9 +8,6 @@ export default function events(state = {}, action) {
         ...state,
         [action.eventID]: action.event,
       };
-
-    case SET_EVENTS:
-      return action.events;
 
     case SITE_STATE_LOADED:
       return action.events;

--- a/app/reducers/events/test.js
+++ b/app/reducers/events/test.js
@@ -1,6 +1,6 @@
 import deepFreeze from 'deep-freeze';
 import reducer from '.';
-import { updateEvent, setEvents } from '../../actions/community_events';
+import { updateEvent } from '../../actions/community_events';
 import { siteStateLoaded } from '../../actions/persistence';
 
 describe('events reducer', () => {
@@ -37,23 +37,8 @@ describe('events reducer', () => {
     });
   });
 
-  describe('SET_EVENTS handling', () => {
-    it('adds the event when the ID is new', () => {
-      const prev = deepFreeze({ 5: { title: 'React London 5' } });
-      const action = setEvents({
-        3: { title: 'React Thing' },
-        8: { title: 'Redux Thing' },
-      });
-      const state = reducer(prev, action);
-      expect(state).to.deep.equal({
-        3: { title: 'React Thing' },
-        8: { title: 'Redux Thing' },
-      });
-    });
-  });
-
   describe('SITE_STATE_LOADED handling', () => {
-    it('adds the event when the ID is new', () => {
+    it('overwrites the state', () => {
       const prev = deepFreeze({ 5: { title: 'React London 5' } });
       const events = {
         3: { title: 'React Thing' },

--- a/app/reducers/events/test.js
+++ b/app/reducers/events/test.js
@@ -1,7 +1,7 @@
 import deepFreeze from 'deep-freeze';
 import reducer from '.';
 import { updateEvent, setEvents } from '../../actions/community_events';
-import { stateLoaded } from '../../actions/persistence';
+import { siteStateLoaded } from '../../actions/persistence';
 
 describe('events reducer', () => {
   it('has default state', () => {
@@ -52,14 +52,14 @@ describe('events reducer', () => {
     });
   });
 
-  describe('STATE_LOADED handling', () => {
+  describe('SITE_STATE_LOADED handling', () => {
     it('adds the event when the ID is new', () => {
       const prev = deepFreeze({ 5: { title: 'React London 5' } });
       const events = {
         3: { title: 'React Thing' },
         8: { title: 'Redux Thing' },
       };
-      const action = stateLoaded({ events });
+      const action = siteStateLoaded({ events });
       const state = reducer(prev, action);
       expect(state).to.deep.equal({
         3: { title: 'React Thing' },

--- a/app/reducers/events/test.js
+++ b/app/reducers/events/test.js
@@ -1,6 +1,7 @@
 import deepFreeze from 'deep-freeze';
 import reducer from '.';
 import { updateEvent, setEvents } from '../../actions/community_events';
+import { stateLoaded } from '../../actions/persistence';
 
 describe('events reducer', () => {
   it('has default state', () => {
@@ -43,6 +44,22 @@ describe('events reducer', () => {
         3: { title: 'React Thing' },
         8: { title: 'Redux Thing' },
       });
+      const state = reducer(prev, action);
+      expect(state).to.deep.equal({
+        3: { title: 'React Thing' },
+        8: { title: 'Redux Thing' },
+      });
+    });
+  });
+
+  describe('STATE_LOADED handling', () => {
+    it('adds the event when the ID is new', () => {
+      const prev = deepFreeze({ 5: { title: 'React London 5' } });
+      const events = {
+        3: { title: 'React Thing' },
+        8: { title: 'Redux Thing' },
+      };
+      const action = stateLoaded({ events });
       const state = reducer(prev, action);
       expect(state).to.deep.equal({
         3: { title: 'React Thing' },

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -1,12 +1,15 @@
 import { combineReducers } from 'redux';
 import { reducer as form } from 'redux-form';
 import { routerReducer as routing } from 'react-router-redux';
+
 import events from './events';
+import community from './community';
 
 const reducers = combineReducers({
   form,
   routing,
   events,
+  community,
 });
 
 export default reducers;

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -4,12 +4,14 @@ import { routerReducer as routing } from 'react-router-redux';
 
 import events from './events';
 import community from './community';
+import conference from './conference';
 
 const reducers = combineReducers({
   form,
   routing,
   events,
   community,
+  conference,
 });
 
 export default reducers;

--- a/app/reducers/test.js
+++ b/app/reducers/test.js
@@ -7,5 +7,6 @@ describe('Reducers', () => {
     expect(state).to.contain.key('form');
     expect(state).to.contain.key('routing');
     expect(state).to.contain.key('events');
+    expect(state).to.contain.key('community');
   });
 });

--- a/app/reducers/test.js
+++ b/app/reducers/test.js
@@ -8,5 +8,6 @@ describe('Reducers', () => {
     expect(state).to.contain.key('routing');
     expect(state).to.contain.key('events');
     expect(state).to.contain.key('community');
+    expect(state).to.contain.key('conference');
   });
 });

--- a/app/sagas/index.js
+++ b/app/sagas/index.js
@@ -1,0 +1,13 @@
+import { put } from 'redux-saga/effects';
+import { stateLoaded, stateLoadFailed } from '../actions/persistence';
+import * as api from '../api';
+
+export default function * rootSaga() {
+  try {
+    const { data } = yield api.fetchInitialState();
+    yield put(stateLoaded(data));
+  } catch (e) {
+    console.log('error:', e);
+    yield put(stateLoadFailed(e));
+  }
+}

--- a/app/sagas/index.js
+++ b/app/sagas/index.js
@@ -1,13 +1,7 @@
-import { put } from 'redux-saga/effects';
-import { stateLoaded, stateLoadFailed } from '../actions/persistence';
-import * as api from '../api';
+import { fork } from 'redux-saga/effects';
 
-export default function * rootSaga() {
-  try {
-    const { data } = yield api.fetchInitialState();
-    yield put(stateLoaded(data));
-  } catch (e) {
-    console.log('error:', e);
-    yield put(stateLoadFailed(e));
-  }
+import { loadStateWorker } from './load-state';
+
+export default function* rootSaga() {
+  yield fork(loadStateWorker);
 }

--- a/app/sagas/load-state/index.js
+++ b/app/sagas/load-state/index.js
@@ -1,9 +1,9 @@
-import { put } from 'redux-saga/effects';
+import { put, call } from 'redux-saga/effects';
 import { stateLoaded, stateLoadFailed } from '../../actions/persistence';
 import * as api from '../../api';
 
 export function* loadStateWorker() {
-  const res = yield api.fetchSiteState();
+  const res = yield call(api.fetchSiteState);
   if (res.error) {
     yield put(stateLoadFailed(res.error));
   } else {

--- a/app/sagas/load-state/index.js
+++ b/app/sagas/load-state/index.js
@@ -1,0 +1,12 @@
+import { put } from 'redux-saga/effects';
+import { stateLoaded, stateLoadFailed } from '../../actions/persistence';
+import * as api from '../../api';
+
+export function* loadStateWorker() {
+  const res = yield api.fetchSiteState();
+  if (res.error) {
+    yield put(stateLoadFailed(res.error));
+  } else {
+    yield put(stateLoaded(res.data));
+  }
+}

--- a/app/sagas/load-state/index.js
+++ b/app/sagas/load-state/index.js
@@ -1,12 +1,14 @@
 import { put, call } from 'redux-saga/effects';
-import { stateLoaded, stateLoadFailed } from '../../actions/persistence';
 import * as api from '../../api';
+import {
+  siteStateLoaded, siteStateLoadFailed,
+} from '../../actions/persistence';
 
 export function* loadStateWorker() {
   const res = yield call(api.fetchSiteState);
   if (res.error) {
-    yield put(stateLoadFailed(res.error));
+    yield put(siteStateLoadFailed(res.error));
   } else {
-    yield put(stateLoaded(res.data));
+    yield put(siteStateLoaded(res.data));
   }
 }

--- a/app/sagas/load-state/test.js
+++ b/app/sagas/load-state/test.js
@@ -1,0 +1,42 @@
+import { loadStateWorker } from '.';
+import { put, call } from 'redux-saga/effects';
+import { stateLoaded, stateLoadFailed } from '../../actions/persistence';
+import * as api from '../../api';
+
+describe('saga loadStateWorker', () => {
+  it('fetches state from API and handles success', () => {
+    const generator = loadStateWorker();
+    expect(
+      generator.next().value
+    ).to.deep.equal(
+      call(api.fetchSiteState)
+    );
+    const response = {
+      data: {
+        events: [1, 2],
+        community: 'comm',
+        conference: 'conf',
+      },
+    };
+    expect(
+      generator.next(response).value
+    ).to.deep.equal(
+      put(stateLoaded(response.data))
+    );
+  });
+
+  it('fetches state from API and handles failure', () => {
+    const generator = loadStateWorker();
+    expect(
+      generator.next().value
+    ).to.deep.equal(
+      call(api.fetchSiteState)
+    );
+    const response = { error: 'sadness :(' };
+    expect(
+      generator.next(response).value
+    ).to.deep.equal(
+      put(stateLoadFailed(response.error))
+    );
+  });
+});

--- a/app/sagas/load-state/test.js
+++ b/app/sagas/load-state/test.js
@@ -1,7 +1,10 @@
 import { loadStateWorker } from '.';
 import { put, call } from 'redux-saga/effects';
-import { stateLoaded, stateLoadFailed } from '../../actions/persistence';
 import * as api from '../../api';
+import {
+  siteStateLoaded,
+  siteStateLoadFailed,
+} from '../../actions/persistence';
 
 describe('saga loadStateWorker', () => {
   it('fetches state from API and handles success', () => {
@@ -21,7 +24,7 @@ describe('saga loadStateWorker', () => {
     expect(
       generator.next(response).value
     ).to.deep.equal(
-      put(stateLoaded(response.data))
+      put(siteStateLoaded(response.data))
     );
   });
 
@@ -36,7 +39,7 @@ describe('saga loadStateWorker', () => {
     expect(
       generator.next(response).value
     ).to.deep.equal(
-      put(stateLoadFailed(response.error))
+      put(siteStateLoadFailed(response.error))
     );
   });
 });

--- a/app/store/index.js
+++ b/app/store/index.js
@@ -25,8 +25,8 @@ import saga from '../sagas';
 // Store
 
 const middleware = compose(
-  devtoolsMiddleware,
-  applyMiddleware(sagaMiddleware)
+  applyMiddleware(sagaMiddleware),
+  devtoolsMiddleware
 );
 
 export const configureStore = initialState => {

--- a/circle.yml
+++ b/circle.yml
@@ -2,8 +2,8 @@ machine:
   node:
     version: 6.0.0
 
-## Customize test commands
 test:
   override:
+    - make build
     - make lint
     - make test

--- a/mocha-env.js
+++ b/mocha-env.js
@@ -5,6 +5,11 @@
 
 // import es6
 require('babel-register');
+// Generator polyfill
+require('babel-polyfill');
+
+// Mock fetch
+global.fetch = () => { throw new Error('fetch called in tests'); };
 
 var chai = require('chai');
 chai.use(require('dirty-chai')); // Function form for terminating assertions

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "body-parser": "^1.15.1",
     "cookie-session": "^2.0.0-alpha.1",
     "css-loader": "^0.23.1",
-    "deep-freeze": "0.0.1",
     "dotenv": "^2.0.0",
     "es6-promise": "^3.1.2",
     "eslint": "^2.11.1",
@@ -49,6 +48,7 @@
     "isomorphic-fetch": "^2.2.1",
     "mkdirp": "^0.5.1",
     "morgan": "^1.7.0",
+    "node-sass": "^3.8.0",
     "passport": "^0.3.2",
     "passport-google-oauth20": "^1.0.0",
     "react": "^15.0.1",
@@ -59,8 +59,8 @@
     "react-scribe": "^0.2.6",
     "redux": "^3.5.2",
     "redux-form": "^6.0.0-alpha.13",
-    "sass-loader": "^3.2.1",
     "redux-saga": "^0.10.5",
+    "sass-loader": "^3.2.1",
     "serialize-javascript": "^1.2.0",
     "style-loader": "^0.13.1",
     "webpack": "^1.13.0",
@@ -68,7 +68,6 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "css-loader": "^0.23.1",
     "deep-freeze": "0.0.1",
     "dirty-chai": "^1.2.2",
     "enzyme": "^2.3.0",
@@ -77,7 +76,6 @@
     "mocha": "^2.4.5",
     "react-addons-test-utils": "^15.1.0",
     "react-testutils-additions": "^15.1.0",
-    "style-loader": "^0.13.1",
     "supertest": "^1.2.0",
     "webpack-dev-server": "^1.14.1"
   }

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "webpack-dev-middleware": "^1.6.1"
   },
   "devDependencies": {
+    "babel-polyfill": "^6.9.1",
     "chai": "^3.5.0",
     "deep-freeze": "0.0.1",
     "dirty-chai": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint-plugin-jsx-a11y": "^1.3.0",
     "eslint-plugin-react": "^5.1.1",
     "express": "^4.13.4",
+    "extract-text-webpack-plugin": "^1.0.1",
     "html-janitor": "^2.0.2",
     "html-minifier": "^2.1.2",
     "isomorphic-fetch": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "redux": "^3.5.2",
     "redux-form": "^6.0.0-alpha.13",
     "sass-loader": "^3.2.1",
+    "redux-saga": "^0.10.5",
     "serialize-javascript": "^1.2.0",
     "style-loader": "^0.13.1",
     "webpack": "^1.13.0",

--- a/server/index.js
+++ b/server/index.js
@@ -28,6 +28,6 @@ app.listen(port, error => {
   if (error) {
     logger.error(error);
   } else {
-    logger.info('==> 🌎  Listening on port %s.', port);
+    logger.info(`==> 🌎  Listening on port ${port}.`);
   }
 });

--- a/server/routing/index.js
+++ b/server/routing/index.js
@@ -15,8 +15,15 @@ export const routingSetup = (app) => {
 
   app.get('/site/', (req, res) => {
     storage.get('data/site.json')
-      .then(data => res.set('Content-Type', 'Application/JSON').send(data))
-      .catch(() => res.sendStatus(503));
+      .then(data =>
+        res.status(200)
+          .set('Content-Type', 'Application/JSON')
+          .send(data)
+      )
+      .catch(() =>
+        res.status(404)
+          .json({ error: 'Cannot load site state.' })
+      );
   });
 
   app.post('/site/', (req, res) => {

--- a/server/routing/page.js
+++ b/server/routing/page.js
@@ -1,0 +1,10 @@
+import path from 'path';
+
+export function notFound(req, res) {
+  res.sendStatus(404);
+}
+
+export function index(req, res) {
+  const filePath = path.join(__dirname, '../../app', 'index.html');
+  res.sendFile(filePath);
+}

--- a/server/routing/site.js
+++ b/server/routing/site.js
@@ -1,0 +1,26 @@
+import * as storage from '../storage';
+import { compileSite } from '../static-site';
+import { publishSite } from '../publish';
+
+export function create(req, res) {
+  const site = compileSite(req.body);
+  Promise.all([
+    publishSite(site),
+    storage.put('data/site.json', JSON.stringify(req.body)),
+  ])
+  .then(() => res.sendStatus(201))
+  .catch(() => res.sendStatus(503));
+}
+
+export function show(req, res) {
+  storage.get('data/site.json')
+    .then(data =>
+      res.status(200)
+        .set('Content-Type', 'Application/JSON')
+        .send(data)
+    )
+    .catch(() =>
+      res.status(404)
+        .json({ error: 'Cannot load site state.' })
+    );
+}

--- a/server/routing/site.js
+++ b/server/routing/site.js
@@ -16,8 +16,8 @@ export function show(req, res) {
   storage.get('data/site.json')
     .then(data =>
       res.status(200)
-        .set('Content-Type', 'Application/JSON')
-        .send(data)
+        .set('Content-Type', 'Application/json')
+        .send(`{"data":${data}}`)
     )
     .catch(() =>
       res.status(404)

--- a/server/routing/test.js
+++ b/server/routing/test.js
@@ -132,7 +132,8 @@ describe('GET /site/', () => {
     const app = setup();
     request(app)
       .get('/site/')
-      .expect(200, { hello: 'world' })
+      .expect('Content-Type', /json/)
+      .expect(200, { data: { hello: 'world' } })
       .end((err) => {
         if (err) throw err;
         done();
@@ -144,6 +145,7 @@ describe('GET /site/', () => {
     const app = setup();
     request(app)
       .get('/site/')
+      .expect('Content-Type', /json/)
       .expect(404)
       .end((err) => {
         if (err) throw err;

--- a/server/routing/test.js
+++ b/server/routing/test.js
@@ -139,12 +139,12 @@ describe('GET /site/', () => {
       });
   });
 
-  it('500s when unable to get data', done => {
+  it('404s when unable to get data', done => {
     useFailStore();
     const app = setup();
     request(app)
       .get('/site/')
-      .expect(503)
+      .expect(404)
       .end((err) => {
         if (err) throw err;
         done();


### PR DESCRIPTION

![kitty-run](https://cloud.githubusercontent.com/assets/6134406/16338499/0c5f1dae-3a15-11e6-8d1c-b425a963ff67.gif)

- [x] Gif
- [x] Split router based upon resource/concerns
- [x] Saga to load initial site state
- [x] Tested