### PR TITLE
api module: Throw on unsuccessful fetch

### DIFF
--- a/app/api.js
+++ b/app/api.js
@@ -4,6 +4,11 @@ export function fetchSiteState() {
   return fetch(SITE_ENDPOINT, {
     credentials: 'same-origin',
   })
-  .then(response => response.json())
+  .then(response => {
+    if (response.status === 200) {
+      return response.json();
+    }
+    throw new Error('Unable to load site content from server');
+  })
   .catch(error => { throw error; });
 }

--- a/app/sagas/load-state/index.js
+++ b/app/sagas/load-state/index.js
@@ -5,10 +5,10 @@ import {
 } from '../../actions/persistence';
 
 export function* loadStateWorker() {
-  const res = yield call(api.fetchSiteState);
-  if (res.error) {
-    yield put(siteStateLoadFailed(res.error));
-  } else {
+  try {
+    const res = yield call(api.fetchSiteState);
     yield put(siteStateLoaded(res.data));
+  } catch (error) {
+    yield put(siteStateLoadFailed(error));
   }
 }

--- a/app/sagas/load-state/test.js
+++ b/app/sagas/load-state/test.js
@@ -26,6 +26,7 @@ describe('saga loadStateWorker', () => {
     ).to.deep.equal(
       put(siteStateLoaded(response.data))
     );
+    expect(generator.next().done).to.equal(true);
   });
 
   it('fetches state from API and handles failure', () => {
@@ -35,11 +36,11 @@ describe('saga loadStateWorker', () => {
     ).to.deep.equal(
       call(api.fetchSiteState)
     );
-    const response = { error: 'sadness :(' };
     expect(
-      generator.next(response).value
+      generator.throw('an error occured!').value
     ).to.deep.equal(
-      put(siteStateLoadFailed(response.error))
+      put(siteStateLoadFailed('an error occured!'))
     );
+    expect(generator.next().done).to.equal(true);
   });
 });


### PR DESCRIPTION
It seems like it might be a sensible convention to use exceptions as a way of jumping to the sad path for API calls as there's no other good error handling pipeline in Javascript.