### PR TITLE
Track whether the user has unsaved changes

### DIFF
--- a/app/reducers/events/test.js
+++ b/app/reducers/events/test.js
@@ -7,8 +7,7 @@ import { eventIDToFormName } from '../../names/event';
 
 describe('events reducer', () => {
   it('has default state', () => {
-    const prev = deepFreeze({});
-    const state = reducer(undefined, prev);
+    const state = reducer(undefined, {});
     expect(state).to.deep.equal({});
   });
 

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -5,6 +5,7 @@ import { routerReducer as routing } from 'react-router-redux';
 import events from './events';
 import community from './community';
 import conference from './conference';
+import unsavedChanges from './unsaved-changes';
 
 const reducers = combineReducers({
   form,
@@ -12,6 +13,7 @@ const reducers = combineReducers({
   events,
   community,
   conference,
+  unsavedChanges,
 });
 
 export default reducers;

--- a/app/reducers/test.js
+++ b/app/reducers/test.js
@@ -9,5 +9,6 @@ describe('Reducers', () => {
     expect(state).to.contain.key('events');
     expect(state).to.contain.key('community');
     expect(state).to.contain.key('conference');
+    expect(state).to.contain.key('unsavedChanges');
   });
 });

--- a/app/reducers/unsaved-changes/index.js
+++ b/app/reducers/unsaved-changes/index.js
@@ -1,9 +1,10 @@
 import { actionTypes as formActions } from 'redux-form';
-import { PUBLISH_SITE_SUCCESS } from '../../actions/persistence';
+import { PUBLISH_SITE_SUCCESS, SITE_STATE_LOADED } from '../../actions/persistence';
 
 export default function unsavedChanges(state = false, action) {
   switch (action.type) {
     case PUBLISH_SITE_SUCCESS:
+    case SITE_STATE_LOADED:
       return false;
 
     case formActions.CHANGE:

--- a/app/reducers/unsaved-changes/index.js
+++ b/app/reducers/unsaved-changes/index.js
@@ -1,0 +1,11 @@
+import { actionTypes as formActions } from 'redux-form';
+
+export default function unsavedChanges(state = false, action) {
+  switch (action.type) {
+    case formActions.CHANGE:
+      return true;
+
+    default:
+      return state;
+  }
+}

--- a/app/reducers/unsaved-changes/index.js
+++ b/app/reducers/unsaved-changes/index.js
@@ -1,7 +1,11 @@
 import { actionTypes as formActions } from 'redux-form';
+import { PUBLISH_SITE_SUCCESS } from '../../actions/persistence';
 
 export default function unsavedChanges(state = false, action) {
   switch (action.type) {
+    case PUBLISH_SITE_SUCCESS:
+      return false;
+
     case formActions.CHANGE:
       return true;
 

--- a/app/reducers/unsaved-changes/test.js
+++ b/app/reducers/unsaved-changes/test.js
@@ -1,6 +1,6 @@
 import reducer from '.';
 import { change as formFieldChange } from 'redux-form';
-import { publishSiteSuccess } from '../../actions/persistence';
+import { publishSiteSuccess, siteStateLoaded } from '../../actions/persistence';
 
 describe('events reducer', () => {
   it('has default state', () => {
@@ -20,10 +20,19 @@ describe('events reducer', () => {
     });
   });
 
-  describe('PUBLISH_SITE_SUCCESS', () => {
+  describe('PUBLISH_SITE_SUCCESS handling', () => {
     it('registers all changes as saved', () => {
       const prev = true;
       const action = publishSiteSuccess();
+      const state = reducer(prev, action);
+      expect(state).to.equal(false);
+    });
+  });
+
+  describe('SITE_STATE_LOADED handling', () => {
+    it('registers all changes as saved', () => {
+      const prev = true;
+      const action = siteStateLoaded({});
       const state = reducer(prev, action);
       expect(state).to.equal(false);
     });

--- a/app/reducers/unsaved-changes/test.js
+++ b/app/reducers/unsaved-changes/test.js
@@ -1,0 +1,21 @@
+import reducer from '.';
+import { change as formFieldChange } from 'redux-form';
+
+describe('events reducer', () => {
+  it('has default state', () => {
+    const state = reducer(undefined, {});
+    expect(state).to.deep.equal(false);
+  });
+
+
+  describe('redux-form/CHANGE handling', () => {
+    it('registers changes as unsaved', () => {
+      const prev = false;
+      const action = formFieldChange(
+        'community', 'communityTitle', 'New Important Title'
+      );
+      const state = reducer(prev, action);
+      expect(state).to.equal(true);
+    });
+  });
+});

--- a/app/reducers/unsaved-changes/test.js
+++ b/app/reducers/unsaved-changes/test.js
@@ -1,5 +1,6 @@
 import reducer from '.';
 import { change as formFieldChange } from 'redux-form';
+import { publishSiteSuccess } from '../../actions/persistence';
 
 describe('events reducer', () => {
   it('has default state', () => {
@@ -16,6 +17,15 @@ describe('events reducer', () => {
       );
       const state = reducer(prev, action);
       expect(state).to.equal(true);
+    });
+  });
+
+  describe('PUBLISH_SITE_SUCCESS', () => {
+    it('registers all changes as saved', () => {
+      const prev = true;
+      const action = publishSiteSuccess();
+      const state = reducer(prev, action);
+      expect(state).to.equal(false);
     });
   });
 });


### PR DESCRIPTION
![space-save](https://cloud.githubusercontent.com/assets/6134406/16521752/ec13d2f2-3f90-11e6-8c48-e459c582be6b.gif)

- [x] Reducer registers unsaved changes when a field is edited
- [x] Reducer registers no changes when publish is successful
- [x] Reducer registers no changes when state load is successful
- [x] Reducer hooked up to root reducer