### PR TITLE
Enable caching in docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV NODE_ENV=production
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-# Install app dependencies
+# Install app dependencies if changed
 COPY package.json /usr/src/app/
 RUN npm install --production
 

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -23,8 +23,8 @@ eval $(aws ecr get-login --region=$AWS_REGION)
 
 # Build Docker image
 VERSION=$RELEASE_TAG
-docker build -t $APP_NAME:$RELEASE_TAG .
-docker tag $APP_NAME:$RELEASE_TAG $ECR_REPO:$RELEASE_TAG
+docker build -t $APP_NAME .
+docker tag $APP_NAME $ECR_REPO:$RELEASE_TAG
 docker push $ECR_REPO:$RELEASE_TAG
 
 # Apply docker image path to Dockerrun.aws.json template


### PR DESCRIPTION
This prevents npm install from running EVERY TIME.