### PR TITLE
Get future events from Badger Brain

### DIFF
--- a/server/data/badger-brain.js
+++ b/server/data/badger-brain.js
@@ -25,6 +25,7 @@ query {
     mailingListSummary
     events {
       title
+      eventType
       ticketsAvailable
       waitingListOpen
       displayLevel

--- a/shared/components/Community/index.js
+++ b/shared/components/Community/index.js
@@ -10,34 +10,12 @@ import MailingList from '../MailingList';
 import JoinSlack from '../JoinSlack';
 import FutureEvents from '../FutureEvents';
 
-const events = [
-  {
-    title: 'September Meetup 2016',
-    date: 'Wed, 21st September 2016',
-    location: 'Skillsmatter',
-  },
-  {
-    title: 'October Meetup 2016',
-    date: 'Tues, 18th October 2016',
-    location: 'Facebook',
-  },
-  {
-    title: 'React London 2017',
-    date: 'Tues, 28th March 2017',
-    location: 'QEII Center, London SW1P 3EE',
-  },
-  {
-    title: 'React London Meetup November 2016',
-    date: 'Tuesday, 7th November 2016',
-    location: 'Bloomberg',
-  },
-];
-
 const Community = ({
   summary,
   mailingListTitle,
   mailingListSummary,
   featuredEvent,
+  futureEvents,
 }) => (
   <div className="community">
     <div id="wrapper">
@@ -56,7 +34,7 @@ const Community = ({
         eventSponsors={featuredEvent.sponsors}
       />
       <JoinSlack />
-      <FutureEvents events={events} />
+      <FutureEvents events={futureEvents} />
       <SiteFooter />
     </div>
   </div>
@@ -68,6 +46,7 @@ Community.propTypes = {
   mailingListSummary: PropTypes.string,
   events: PropTypes.arrayOf(PropTypes.shape(NextCommunityEvent.propTypes)),
   featuredEvent: PropTypes.shape(EventDetails.propTypes),
+  futureEvents: FutureEvents.propTypes.events,
 };
 
 export default Community;

--- a/shared/components/FutureEvent/index.js
+++ b/shared/components/FutureEvent/index.js
@@ -1,8 +1,20 @@
 import React, { PropTypes } from 'react';
+import { formatDate } from '../../utilities/date';
 
 export const placeholderText = 'To be confirmed';
 
-const FutureEvent = ({ title, date, location }) => {
+function address(location) {
+  return location && location.address || placeholderText;
+}
+
+function dateText(date) {
+  if (date) {
+    return formatDate(date, 'dddd, Do MMMM YYYY');
+  }
+  return placeholderText;
+}
+
+const FutureEvent = ({ title, startDateTime, location }) => {
   if (!title) { return null; }
   return (
     <div className="FutureEvent">
@@ -11,10 +23,10 @@ const FutureEvent = ({ title, date, location }) => {
       </h3>
       <ul className="FutureEvent__details">
         <li className="FutureEvent__datetime">
-          {date || placeholderText}
+          {dateText(startDateTime)}
         </li>
         <li className="FutureEvent__location">
-          {location || placeholderText}
+          {address(location)}
         </li>
       </ul>
     </div>
@@ -23,8 +35,8 @@ const FutureEvent = ({ title, date, location }) => {
 
 FutureEvent.propTypes = {
   title: PropTypes.string,
-  date: PropTypes.string,
-  location: PropTypes.string,
+  startDateTime: PropTypes.shape({ iso: PropTypes.string }),
+  location: PropTypes.shape({ address: PropTypes.string }),
 };
 
 export default FutureEvent;

--- a/shared/components/FutureEvent/index.js
+++ b/shared/components/FutureEvent/index.js
@@ -14,10 +14,18 @@ function dateText(date) {
   return placeholderText;
 }
 
-const FutureEvent = ({ title, startDateTime, location }) => {
+function classes(eventType) {
+  if (eventType) {
+    const type = eventType.replace(/[^a-z]/gi, '-');
+    return `FutureEvent FutureEvent--${type}`;
+  }
+  return 'FutureEvent';
+}
+
+const FutureEvent = ({ title, eventType, startDateTime, location }) => {
   if (!title) { return null; }
   return (
-    <div className="FutureEvent">
+    <div className={classes(eventType)}>
       <h3 className="FutureEvent__title">
         {title}
       </h3>
@@ -35,6 +43,7 @@ const FutureEvent = ({ title, startDateTime, location }) => {
 
 FutureEvent.propTypes = {
   title: PropTypes.string,
+  eventType: PropTypes.string,
   startDateTime: PropTypes.shape({ iso: PropTypes.string }),
   location: PropTypes.shape({ address: PropTypes.string }),
 };

--- a/shared/components/FutureEvent/test.js
+++ b/shared/components/FutureEvent/test.js
@@ -6,19 +6,29 @@ describe('FutureEvent component', () => {
   it('renders OK when props passed', () => {
     const props = {
       title: 'The title',
-      date: 'The date',
-      location: 'The location',
+      location: {
+        address: 'The location',
+      },
+      startDateTime: {
+        iso: '2016-08-10',
+      },
     };
     const el = shallow(<FutureEvent {...props} />);
     expect(el.find('.FutureEvent__title').text()).to.equal('The title');
-    expect(el.find('.FutureEvent__datetime').text()).to.equal('The date');
     expect(el.find('.FutureEvent__location').text()).to.equal('The location');
+    expect(el.find('.FutureEvent__datetime').text()).to.equal(
+      'Wednesday, 10th August 2016'
+    );
   });
 
   it('renders nothing when title is missing', () => {
     const props = {
-      date: 'The date',
-      location: 'The location',
+      location: {
+        address: 'The location',
+      },
+      startDateTime: {
+        iso: '2016-08-10',
+      },
     };
     const el = shallow(<FutureEvent {...props} />);
     expect(el.html()).to.equal(null);
@@ -27,7 +37,9 @@ describe('FutureEvent component', () => {
   it('has fallback text for date', () => {
     const props = {
       title: 'The title',
-      location: 'The location',
+      location: {
+        address: 'The location',
+      },
     };
     const el = shallow(<FutureEvent {...props} />);
     expect(el.find('.FutureEvent__datetime').text()).to.equal(placeholderText);
@@ -36,7 +48,9 @@ describe('FutureEvent component', () => {
   it('has fallback text for location', () => {
     const props = {
       title: 'The title',
-      date: 'The date',
+      startDateTime: {
+        iso: '2016-08-10',
+      },
     };
     const el = shallow(<FutureEvent {...props} />);
     expect(el.find('.FutureEvent__location').text()).to.equal(placeholderText);

--- a/shared/components/FutureEvent/test.js
+++ b/shared/components/FutureEvent/test.js
@@ -55,4 +55,17 @@ describe('FutureEvent component', () => {
     const el = shallow(<FutureEvent {...props} />);
     expect(el.find('.FutureEvent__location').text()).to.equal(placeholderText);
   });
+
+
+  it('adds a class for the eventType', () => {
+    const props = {
+      title: 'The title',
+      startDateTime: {
+        iso: '2016-08-10',
+      },
+      eventType: 'Dance ! Party',
+    };
+    const el = shallow(<FutureEvent {...props} />);
+    expect(el.find('.FutureEvent').props().className).to.include('FutureEvent--Dance---Party');
+  });
 });

--- a/shared/components/FutureEvents/index.scss
+++ b/shared/components/FutureEvents/index.scss
@@ -30,6 +30,9 @@
 
   &:last-child {
     border-right: none;
+  }
+
+  &--Conference {
     background-color: $conference-color;
   }
 

--- a/shared/containers/Community/index.js
+++ b/shared/containers/Community/index.js
@@ -1,6 +1,14 @@
 import { connect } from 'react-redux';
 import Community from '../../components/Community';
 
+function featuredEvent(events) {
+  return events.find(e => e.displayLevel === 'Featured') || {};
+}
+
+function futureEvents(events) {
+  return events.filter(e => e.displayLevel === 'Highlighted').slice(0, 3);
+}
+
 export const mapStateToProps = (state) => {
   if (!state || !state.community) { return {}; }
   const {
@@ -15,7 +23,8 @@ export const mapStateToProps = (state) => {
     summary,
     mailingListTitle,
     mailingListSummary,
-    featuredEvent: events.find(e => e.displayLevel === 'Featured') || {},
+    featuredEvent: featuredEvent(events),
+    futureEvents: futureEvents(events),
   };
 };
 

--- a/shared/containers/Community/index.js
+++ b/shared/containers/Community/index.js
@@ -1,12 +1,16 @@
 import { connect } from 'react-redux';
 import Community from '../../components/Community';
 
+const MAX_EVENTS = 3;
+
 function featuredEvent(events) {
   return events.find(e => e.displayLevel === 'Featured') || {};
 }
 
 function futureEvents(events) {
-  return events.filter(e => e.displayLevel === 'Highlighted').slice(0, 3);
+  return events
+    .filter(e => e.displayLevel === 'Highlighted')
+    .slice(0, MAX_EVENTS);
 }
 
 export const mapStateToProps = (state) => {

--- a/shared/containers/Community/test.js
+++ b/shared/containers/Community/test.js
@@ -14,6 +14,7 @@ describe('Community mapStateToProps', () => {
       'mailingListTitle',
       'mailingListSummary',
       'featuredEvent',
+      'futureEvents',
     ]);
     expect(state.title).to.equal(community.title);
     expect(state.summary).to.equal(community.summary);
@@ -50,6 +51,40 @@ describe('Community mapStateToProps', () => {
       const data = { community: { ...fixture.community, events } };
       const state = mapStateToProps(data);
       expect(state.featuredEvent).to.deep.equal({});
+    });
+  });
+
+  describe('futureEvents selection', () => {
+    it('selects the first 3 highlighted events', () => {
+      const events = deepFreeze([
+        { title: '1', displayLevel: 'Regular' },
+        { title: '2', displayLevel: 'Highlighted' },
+        { title: '3', displayLevel: 'Featured' },
+        { title: '3', displayLevel: 'Highlighted' },
+        { title: '4', displayLevel: 'Highlighted' },
+        { title: '5', displayLevel: 'Featured' },
+        { title: '6', displayLevel: 'Highlighted' },
+        { title: '7', displayLevel: 'Highlighted' },
+      ]);
+      const data = { community: { ...fixture.community, events } };
+      const state = mapStateToProps(data);
+      expect(state.futureEvents).to.deep.equal([
+        { title: '2', displayLevel: 'Highlighted' },
+        { title: '3', displayLevel: 'Highlighted' },
+        { title: '4', displayLevel: 'Highlighted' },
+      ]);
+    });
+
+    it('gets as many as possible if there are less than 3', () => {
+      const events = deepFreeze([
+        { title: '1', displayLevel: 'Regular' },
+        { title: '2', displayLevel: 'Highlighted' },
+      ]);
+      const data = { community: { ...fixture.community, events } };
+      const state = mapStateToProps(data);
+      expect(state.futureEvents).to.deep.equal([
+        { title: '2', displayLevel: 'Highlighted' },
+      ]);
     });
   });
 });

--- a/test/fixtures/badger-brain-payload.json
+++ b/test/fixtures/badger-brain-payload.json
@@ -8,6 +8,7 @@
       "events": [
         {
           "title": "React London Meetup July 2016",
+          "eventType": "Featured",
           "ticketsAvailable": false,
           "waitingListOpen": false,
           "displayLevel": "Featured",
@@ -106,6 +107,7 @@
         },
         {
           "title": "August React London Meetup",
+          "eventType": null,
           "ticketsAvailable": false,
           "waitingListOpen": false,
           "displayLevel": "Highlighted",


### PR DESCRIPTION
![cash](https://cloud.githubusercontent.com/assets/6134406/17560506/3dda15e4-5f1a-11e6-8a15-43d2a5f9f216.gif)

- [x] Query BB for eventType
- [x] Get highlighted events from BB and use as futureEvents
- [x] Insert into UI
- [x] Conference events are blue.

## Test plan

- Set the events in the react london community to be of an eventType other than "Highlighted" and visit the site. The future events section should not render.
- Add "Highlighted" to one RL event's eventType field. That one event should render on the site.
- Add "Highlighted" to one RL event's eventType field. The two events should render on the site.
- Add "Highlighted" to one RL event's eventType field. The three events should render on the site.
- Add "Highlighted" to one RL event's eventType field. The top three events *only* should render on the site.
- If one of the events listed as highlight in RL is a conference it will be blue.