### PR TITLE
Adding Burger Navigation to conference page

### DIFF
--- a/shared/components/Conference/index.js
+++ b/shared/components/Conference/index.js
@@ -4,6 +4,7 @@ import Hero from '../Hero';
 import RedBadgerBanner from '../RedBadgerBanner';
 import MailingList from '../MailingList';
 import ConferenceAbout from '../ConferenceAbout';
+import NavigationBar from '../NavigationBar';
 import NextConferenceEvent from '../NextConferenceEvent';
 import ShareYourIdeas from '../ShareYourIdeas';
 
@@ -13,6 +14,7 @@ const Conference = () => (
       <main>
         <Hero page="Conference" />
         <RedBadgerBanner />
+        <NavigationBar />
         <ConferenceAbout />
         <NextConferenceEvent />
         <MailingList

--- a/shared/components/Conference/index.js
+++ b/shared/components/Conference/index.js
@@ -1,18 +1,47 @@
 import React from 'react';
-// import SiteFooter from '../SiteFooter';
-// import Hero from '../Hero';
-// import RedBadgerBanner from '../RedBadgerBanner';
-// import MailingList from '../MailingList';
-// import ConferenceAbout from '../ConferenceAbout';
-// import NextConferenceEvent from '../NextConferenceEvent';
-// import ShareYourIdeas from '../ShareYourIdeas';
-import NavigationBar from '../NavigationBar';
+import SiteFooter from '../SiteFooter';
+import Hero from '../Hero';
+import RedBadgerBanner from '../RedBadgerBanner';
+import MailingList from '../MailingList';
+import ConferenceAbout from '../ConferenceAbout';
+import NextConferenceEvent from '../NextConferenceEvent';
+import ShareYourIdeas from '../ShareYourIdeas';
+
+const sssh = {
+  whatdoesthe___say: {
+    flip: 'Gur orfg jnl gb',
+    open: ' yrnea vf ol qbvat',
+    xoyo: ' vg jebat. - Qna Noenzbi',
+  },
+  bite: {
+    alias: 'Yvfc vfa\'g n ynathntr,',
+    noop: ' vg\'f n ohvyqvat zngrevny.',
+    tail: ' - Nyna Xnl',
+  },
+  other: {
+    moo: {
+      category: 'Ižql xóq , nxb xrol gra ',
+      ouch: ', xgb fxbačí hqežnť iáš xóq ohqr aáfvyaý cflpubcng ,',
+      watch: ' xgbeý ivr, xqr žvwrgr . - Evpx Bfobear',
+    },
+  },
+};
 
 const Conference = () => (
   <div className="conference">
     <div id="wrapper">
       <main>
-        <NavigationBar />
+        <Hero page="Conference" />
+        <RedBadgerBanner />
+        <ConferenceAbout />
+        <NextConferenceEvent sssh={sssh} />
+        <MailingList
+          mailingListTitle="Stay tuned"
+          mailingListSummary="Get ticket reminders and event information about the conference."
+          page="conference"
+        />
+        <ShareYourIdeas />
+        <SiteFooter />
       </main>
     </div>
   </div>

--- a/shared/components/Conference/index.js
+++ b/shared/components/Conference/index.js
@@ -1,29 +1,18 @@
 import React from 'react';
-import SiteFooter from '../SiteFooter';
-import Hero from '../Hero';
-import RedBadgerBanner from '../RedBadgerBanner';
-import MailingList from '../MailingList';
-import ConferenceAbout from '../ConferenceAbout';
+// import SiteFooter from '../SiteFooter';
+// import Hero from '../Hero';
+// import RedBadgerBanner from '../RedBadgerBanner';
+// import MailingList from '../MailingList';
+// import ConferenceAbout from '../ConferenceAbout';
+// import NextConferenceEvent from '../NextConferenceEvent';
+// import ShareYourIdeas from '../ShareYourIdeas';
 import NavigationBar from '../NavigationBar';
-import NextConferenceEvent from '../NextConferenceEvent';
-import ShareYourIdeas from '../ShareYourIdeas';
 
 const Conference = () => (
   <div className="conference">
     <div id="wrapper">
       <main>
-        <Hero page="Conference" />
-        <RedBadgerBanner />
         <NavigationBar />
-        <ConferenceAbout />
-        <NextConferenceEvent />
-        <MailingList
-          mailingListTitle="Stay tuned"
-          mailingListSummary="Get ticket reminders and event information about the conference."
-          page="conference"
-        />
-        <ShareYourIdeas />
-        <SiteFooter />
       </main>
     </div>
   </div>

--- a/shared/components/NavigationBar/index.js
+++ b/shared/components/NavigationBar/index.js
@@ -2,18 +2,20 @@ import React from 'react';
 
 const NavigationBar = () => (
   <nav className={'NavigationBar block NavigationBar--Conference'}>
-    <input className="trigger" type="checkbox" id="mainNavButton" />
-    <label htmlFor="mainNavButton">Menu</label>
-    <ul>
-      <li><a href="#">About</a></li>
-      <li><a href="#">Speakers</a></li>
-      <li><a href="#">Schedule</a></li>
-      <li><a href="#">Venue</a></li>
-      <li><a href="#">Partners</a></li>
-      <li><a href="#">Jobs</a></li>
-    </ul>
-    <div className='wild'>
-      <a href="#" className='ticket__button'>Buy tickets</a>
+    <div>
+      <input className="trigger" type="checkbox" id="mainNavButton" />
+      <label htmlFor="mainNavButton">Menu</label>
+      <ul>
+        <li><a href="#">About</a></li>
+        <li><a href="#">Speakers</a></li>
+        <li><a href="#">Schedule</a></li>
+        <li><a href="#">Venue</a></li>
+        <li><a href="#">Partners</a></li>
+        <li><a href="#">Jobs</a></li>
+      </ul>
+    </div>
+    <div className="ticket__button__container">
+      <a href="#" className="ticket__button">Tickets</a>
     </div>
   </nav>
 );

--- a/shared/components/NavigationBar/index.js
+++ b/shared/components/NavigationBar/index.js
@@ -2,14 +2,14 @@ import React from 'react';
 
 const NavigationBar = () => (
   <nav className={'NavigationBar block NavigationBar--Conference'}>
-    <div className='links_container'>
-      <input className="trigger" type="checkbox" id="mainNavButton" />
-      <label htmlFor="mainNavButton">Menu</label>
+    <div className="NavigationBar__links-container">
+      <input className="trigger" type="checkbox" id="burger" />
+      <label htmlFor="burger">Menu</label>
       <ul>
         <li><a href="#">About</a></li>
         <li><a href="#">Speakers</a></li>
         <li><a href="#">Schedule</a></li>
-        <li><a href="#" className='active'>Venue</a></li>
+        <li><a href="#" className="active">Venue</a></li>
         <li><a href="#">Partners</a></li>
         <li><a href="#">Jobs</a></li>
       </ul>

--- a/shared/components/NavigationBar/index.js
+++ b/shared/components/NavigationBar/index.js
@@ -1,18 +1,20 @@
 import React from 'react';
-import { Link } from 'react-router';
 
 const NavigationBar = () => (
   <nav className={'NavigationBar block NavigationBar--Conference'}>
-  <input className="trigger" type="checkbox" id="mainNavButton"/>
-  <label htmlFor="mainNavButton">Menu</label>
-  <ul>
-    <li><a href="#">About</a></li>
-    <li><a href="#">Speakers</a></li>
-    <li><a href="#">Schedule</a></li>
-    <li><a href="#">Venue</a></li>
-    <li><a href="#">Partners</a></li>
-    <li><a href="#">Jobs</a></li>
-  </ul>
+    <input className="trigger" type="checkbox" id="mainNavButton" />
+    <label htmlFor="mainNavButton">Menu</label>
+    <ul>
+      <li><a href="#">About</a></li>
+      <li><a href="#">Speakers</a></li>
+      <li><a href="#">Schedule</a></li>
+      <li><a href="#">Venue</a></li>
+      <li><a href="#">Partners</a></li>
+      <li><a href="#">Jobs</a></li>
+    </ul>
+    <div className='wild'>
+      <a href="#" className='ticket__button'>Buy tickets</a>
+    </div>
   </nav>
 );
 

--- a/shared/components/NavigationBar/index.js
+++ b/shared/components/NavigationBar/index.js
@@ -3,14 +3,16 @@ import { Link } from 'react-router';
 
 const NavigationBar = () => (
   <nav className={'NavigationBar block NavigationBar--Conference'}>
-    <ul className="NavigationBar__tabs">
-      <li>
-        <Link to="community">Meetups</Link>
-      </li>
-      <li>
-        <Link to="conference" activeClassName={"NavigationBar__tab--active"}>Conference</Link>
-      </li>
-    </ul>
+  <input className="trigger" type="checkbox" id="mainNavButton"/>
+  <label htmlFor="mainNavButton">Menu</label>
+  <ul>
+    <li><a href="#">About</a></li>
+    <li><a href="#">Speakers</a></li>
+    <li><a href="#">Schedule</a></li>
+    <li><a href="#">Venue</a></li>
+    <li><a href="#">Partners</a></li>
+    <li><a href="#">Jobs</a></li>
+  </ul>
   </nav>
 );
 

--- a/shared/components/NavigationBar/index.js
+++ b/shared/components/NavigationBar/index.js
@@ -2,14 +2,14 @@ import React from 'react';
 
 const NavigationBar = () => (
   <nav className={'NavigationBar block NavigationBar--Conference'}>
-    <div>
+    <div className='links_container'>
       <input className="trigger" type="checkbox" id="mainNavButton" />
       <label htmlFor="mainNavButton">Menu</label>
       <ul>
         <li><a href="#">About</a></li>
         <li><a href="#">Speakers</a></li>
         <li><a href="#">Schedule</a></li>
-        <li><a href="#">Venue</a></li>
+        <li><a href="#" className='active'>Venue</a></li>
         <li><a href="#">Partners</a></li>
         <li><a href="#">Jobs</a></li>
       </ul>

--- a/shared/components/NavigationBar/index.scss
+++ b/shared/components/NavigationBar/index.scss
@@ -1,10 +1,12 @@
-$flex_nav_breakpoint: 600px;
+$flex_nav_breakpoint: 1100px;
 
 .NavigationBar {
   background-color: $grey;
+  display: flex;
+  padding-left: 44px;
+  padding-right: 44px;
   ul {
     display:none;
-    width:100%;
     list-style:none;
     margin:0px;
     padding:0px;
@@ -31,7 +33,7 @@ $flex_nav_breakpoint: 600px;
     left: -9999px;
     &:checked ~ ul,&:checked ~ ul li ul {
       display:block !important;
-      @media (min-width:$flex_nav_breakpoint){
+      @media (min-width: $tablet-width){
         display: flex;
         flex-direction: row;
       }
@@ -51,6 +53,7 @@ $flex_nav_breakpoint: 600px;
     cursor:pointer;
     line-height: 2em;
     color: $conference-color;
+    flex: 1;
   }
 
   label:before {
@@ -63,10 +66,35 @@ $flex_nav_breakpoint: 600px;
     color: $conference-color;
   }
 
-  @media(min-width:$flex_nav_breakpoint){
+  .wild {
+    flex: 1;
+    .ticket__button {
+      background-color: red;
+      border-radius: 6px;
+      text-transform: uppercase;
+      background-color: #d2091e;
+      color: #fff;
+      cursor: pointer;
+      text-decoration: none;
+      border-radius: 6px;
+      text-transform: uppercase;
+      border: 0;
+      padding: 5px 15px;
+      color: #fff;
+      font-weight: 700;
+      text-decoration: none;
+      text-align: center;
+    }
+  }
+
+
+  @media (min-width: $tablet-width) {
+    display: flex;
+    flex-direction: row;
     ul {
       display: flex;
       flex-direction: row;
+      flex: 5;
       li {
         position:relative;
         text-align: center;
@@ -75,6 +103,12 @@ $flex_nav_breakpoint: 600px;
     }
     label {
       display:none;
+    }
+  }
+
+  @media (min-width: $desktop-width) {
+    ul {
+      flex: 6;
     }
   }
 }

--- a/shared/components/NavigationBar/index.scss
+++ b/shared/components/NavigationBar/index.scss
@@ -5,90 +5,81 @@ body {
 .NavigationBar {
   background-color: $grey;
   display: flex;
-  flex-direction: row;
-  .links_container {
+  &__links-container {
     width: 100%;
-  }
-  div {
-  ul {
-    display:none;
-    list-style:none;
-    margin:0px;
-    padding:0px;
-    flex-direction: column;
-    li {
-      a {
-        padding-left: 80px;
-        display:block;
-        padding-top:14px;
-        padding-bottom:14px;
-        font-weight: bold;
-        font-size: 18px;
-        color: $conference-color;
-        text-decoration:none;
-        &:hover {
-          background:$grey;
-          color: white;
-          @media (max-width: $tablet-width){
+    ul {
+      display: none; /* Not displayed on mobile unless the hamburger menu is opened */
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      flex-direction: column;
+      li {
+        a {
+          padding: 14px 0px 14px 80px;
+          display: block;
+          font-weight: bold;
+          font-size: 18px;
+          color: $conference-color;
+          text-decoration: none;
+          &:hover {
             background: $conference-color;
             color: $grey;
           }
         }
-      }
-      a.active {
-        background: $conference-color;
-        color: $grey;
+        a.active {
+          background: $conference-color;
+          color: $grey;
+        }
       }
     }
   }
-}
 
+  /* Opening menu from hamburger */
   input.trigger {
     position: absolute;
     top: -9999px;
     left: -9999px;
     &:checked ~ ul {
-      @media (max-width: $tablet-width){
-        display:block !important;
+      @media (max-width: $tablet-width) {
+        display: block !important; /* Displaying the menu when the burger is clicked */
         display: flex;
         flex-direction: row;
       }
     }
+    /* When the menu is opened, the hamburger label's text is changed to white */
     &:checked ~ label {
-      @media (max-width: $tablet-width){
+      @media (max-width: $tablet-width) {
         color: white;
       }
     }
+    /* When the menu is opened, the hamburger icon is changed to white */
     &:checked ~ label:before {
-      @media (max-width: $tablet-width){
+      @media (max-width: $tablet-width) {
         color: white;
       }
     }
   }
   label {
-    position:relative;
-    display:block;
+    position: relative;
+    display: block;
     width: 5px;
-    padding-top: 0.5em;
-    padding-left: 35px;
-    padding-bottom: 0.5em;
+    padding: 9px 0px 9px 35px;
     font-size: 18px;
     font-weight: bold;
-    margin:0;
-    cursor:pointer;
+    margin: 0;
+    cursor: pointer;
     line-height: 2em;
     color: $conference-color;
-    flex: 1;
     margin-left: 44px;
   }
-
+  /* Burger icon */
   label:before {
     position: absolute;
-    top: .25em;
-    left: 0em;
-    content:"\2261";
+    top: 8px;
+    left: 0;
+    content: "\2261";
     font-weight: normal;
-    font-size:1.8em;
+    font-size: 30px;
     color: $conference-color;
   }
 
@@ -118,33 +109,36 @@ body {
     }
   }
 
+  /* Tablet and Desktop View */
   @media (min-width: $tablet-width) {
-    display: flex;
-    flex-direction: row;
+    flex-direction: row; /* Changed from column to row as links are now displayed horizontally */
     padding-left: 44px;
     padding-right: 44px;
-    div {
+    &__links-container {
       flex: 6;
-    ul {
-      display: flex;
-      flex-direction: row;
-      li {
-        position:relative;
-        text-align: center;
-        flex: 1;
-        a {
-          padding-left: 0px;
-        }
-        a.active {
-          color: white;
-          background-color: $grey;
-          border-bottom: 3px solid white;
+      ul {
+        display: flex;
+        flex-direction: row;
+        li {
+          text-align: center;
+          flex: 1;
+          a {
+            padding-left: 0;
+          }
+          a.active {
+            color: white;
+            background-color: $grey;
+            border-bottom: 3px solid white;
+          }
+          a:hover {
+            color: white;
+            background-color: $grey;
+          }
         }
       }
     }
-  }
     label {
-      display:none;
+      display: none;
     }
 
     .ticket__button__container {
@@ -152,15 +146,5 @@ body {
       flex: 1;
       right: 20px;
     }
-  }
-
-  @media (min-width: $desktop-width) {
-    div {
-    ul {
-      flex: 6;
-      li {
-      }
-    }
-  }
   }
 }

--- a/shared/components/NavigationBar/index.scss
+++ b/shared/components/NavigationBar/index.scss
@@ -1,11 +1,14 @@
-$flex_nav_breakpoint: 1100px;
+body {
+  background-color: $conference-color;
+}
 
 .NavigationBar {
   background-color: $grey;
   display: flex;
   flex-direction: row;
-  padding-left: 44px;
-  padding-right: 44px;
+  .links_container {
+    width: 100%;
+  }
   div {
   ul {
     display:none;
@@ -15,16 +18,26 @@ $flex_nav_breakpoint: 1100px;
     flex-direction: column;
     li {
       a {
+        padding-left: 80px;
         display:block;
-        padding:14px;
+        padding-top:14px;
+        padding-bottom:14px;
         font-weight: bold;
         font-size: 18px;
         color: $conference-color;
         text-decoration:none;
         &:hover {
           background:$grey;
-          color: $conference-color-faded;
+          color: white;
+          @media (max-width: $tablet-width){
+            background: $conference-color;
+            color: $grey;
+          }
         }
+      }
+      a.active {
+        background: $conference-color;
+        color: $grey;
       }
     }
   }
@@ -35,21 +48,30 @@ $flex_nav_breakpoint: 1100px;
     top: -9999px;
     left: -9999px;
     &:checked ~ ul {
-      display:block !important;
-      @media (min-width: $tablet-width){
+      @media (max-width: $tablet-width){
+        display:block !important;
         display: flex;
         flex-direction: row;
+      }
+    }
+    &:checked ~ label {
+      @media (max-width: $tablet-width){
+        color: white;
+      }
+    }
+    &:checked ~ label:before {
+      @media (max-width: $tablet-width){
+        color: white;
       }
     }
   }
   label {
     position:relative;
     display:block;
-    width: 100%;
-    min-height:2em;
-    padding-top: 0.45em;
-    padding-left: 0px;
-    padding-bottom: 0.45em;
+    width: 5px;
+    padding-top: 0.5em;
+    padding-left: 35px;
+    padding-bottom: 0.5em;
     font-size: 18px;
     font-weight: bold;
     margin:0;
@@ -57,12 +79,13 @@ $flex_nav_breakpoint: 1100px;
     line-height: 2em;
     color: $conference-color;
     flex: 1;
+    margin-left: 44px;
   }
 
   label:before {
     position: absolute;
-    left: -1em;
-    top: .2em;
+    top: .25em;
+    left: 0em;
     content:"\2261";
     font-weight: normal;
     font-size:1.8em;
@@ -71,8 +94,11 @@ $flex_nav_breakpoint: 1100px;
 
   .ticket__button__container {
     position: absolute;
-    top: 15px;
-    right: 20px;
+    right: 44px;
+    top: 12px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
     .ticket__button {
       background-color: red;
       border-radius: 6px;
@@ -95,8 +121,10 @@ $flex_nav_breakpoint: 1100px;
   @media (min-width: $tablet-width) {
     display: flex;
     flex-direction: row;
+    padding-left: 44px;
+    padding-right: 44px;
     div {
-      flex: 5;
+      flex: 6;
     ul {
       display: flex;
       flex-direction: row;
@@ -104,6 +132,14 @@ $flex_nav_breakpoint: 1100px;
         position:relative;
         text-align: center;
         flex: 1;
+        a {
+          padding-left: 0px;
+        }
+        a.active {
+          color: white;
+          background-color: $grey;
+          border-bottom: 3px solid white;
+        }
       }
     }
   }
@@ -114,6 +150,7 @@ $flex_nav_breakpoint: 1100px;
     .ticket__button__container {
       position: initial;
       flex: 1;
+      right: 20px;
     }
   }
 
@@ -121,6 +158,8 @@ $flex_nav_breakpoint: 1100px;
     div {
     ul {
       flex: 6;
+      li {
+      }
     }
   }
   }

--- a/shared/components/NavigationBar/index.scss
+++ b/shared/components/NavigationBar/index.scss
@@ -1,57 +1,80 @@
+$flex_nav_breakpoint: 600px;
+
 .NavigationBar {
-  background: $grey;
+  background-color: $grey;
+  ul {
+    display:none;
+    width:100%;
+    list-style:none;
+    margin:0px;
+    padding:0px;
 
-  li {
-    list-style-type: none;
-
-    @media (min-width: 660px) {
-      width: 280px;
-    }
-  }
-
-  &--Conference {
-    a,
-    a:visited {
-      color: $conference-color;
-    }
-
-    a:focus,
-    a:hover {
-      color: $conference-color-faded;
-    }
-
-
-    a.NavigationBar__tab--active {
-      background-color: $conference-color-faded;
-    }
-  }
-
-  &__tabs {
-    display: flex;
-    flex-flow: row wrap;
-    align-items: center;
-    margin: 0;
-    padding: 0;
-
-    a {
-      $border-bottom-size: 3px;
-
-      text-decoration: none;
-      font-weight: bold;
-      font-size: 20px;
-      width: 40vw;
-      min-width: 130px;
-      text-align: center;
-      height: 50px;
-      vertical-align: middle;
-      display: table-cell;
-      padding-bottom: $border-bottom-size;
-
-      &.NavigationBar__tab--active {
-        color: $grey;
-        border-bottom: $border-bottom-size solid $grey;
-        padding-bottom: 0;
+    li {
+      a {
+        display:block;
+        padding:14px;
+        font-weight: bold;
+        font-size: 18px;
+        color: $conference-color;
+        text-decoration:none;
+        &:hover {
+          background:$grey;
+          color: $conference-color-faded;
+        }
       }
+    }
+  }
+
+  input.trigger {
+    position: absolute;
+    top: -9999px;
+    left: -9999px;
+    &:checked ~ ul,&:checked ~ ul li ul {
+      display:block !important;
+      @media (min-width:$flex_nav_breakpoint){
+        display: flex;
+        flex-direction: row;
+      }
+    }
+  }
+  label {
+    position:relative;
+    display:block;
+    width: 100%;
+    min-height:2em;
+    padding-top: 0.45em;
+    padding-left: 3.5em;
+    padding-bottom: 0.45em;
+    font-size: 18px;
+    font-weight: bold;
+    margin:0;
+    cursor:pointer;
+    line-height: 2em;
+    color: $conference-color;
+  }
+
+  label:before {
+    position: absolute;
+    left: 1em;
+    top: .2em;
+    content:"\2261";
+    font-weight: normal;
+    font-size:1.8em;
+    color: $conference-color;
+  }
+
+  @media(min-width:$flex_nav_breakpoint){
+    ul {
+      display: flex;
+      flex-direction: row;
+      li {
+        position:relative;
+        text-align: center;
+        flex: 1;
+      }
+    }
+    label {
+      display:none;
     }
   }
 }

--- a/shared/components/NavigationBar/index.scss
+++ b/shared/components/NavigationBar/index.scss
@@ -3,14 +3,16 @@ $flex_nav_breakpoint: 1100px;
 .NavigationBar {
   background-color: $grey;
   display: flex;
+  flex-direction: row;
   padding-left: 44px;
   padding-right: 44px;
+  div {
   ul {
     display:none;
     list-style:none;
     margin:0px;
     padding:0px;
-
+    flex-direction: column;
     li {
       a {
         display:block;
@@ -26,12 +28,13 @@ $flex_nav_breakpoint: 1100px;
       }
     }
   }
+}
 
   input.trigger {
     position: absolute;
     top: -9999px;
     left: -9999px;
-    &:checked ~ ul,&:checked ~ ul li ul {
+    &:checked ~ ul {
       display:block !important;
       @media (min-width: $tablet-width){
         display: flex;
@@ -45,7 +48,7 @@ $flex_nav_breakpoint: 1100px;
     width: 100%;
     min-height:2em;
     padding-top: 0.45em;
-    padding-left: 3.5em;
+    padding-left: 0px;
     padding-bottom: 0.45em;
     font-size: 18px;
     font-weight: bold;
@@ -58,7 +61,7 @@ $flex_nav_breakpoint: 1100px;
 
   label:before {
     position: absolute;
-    left: 1em;
+    left: -1em;
     top: .2em;
     content:"\2261";
     font-weight: normal;
@@ -66,8 +69,10 @@ $flex_nav_breakpoint: 1100px;
     color: $conference-color;
   }
 
-  .wild {
-    flex: 1;
+  .ticket__button__container {
+    position: absolute;
+    top: 15px;
+    right: 20px;
     .ticket__button {
       background-color: red;
       border-radius: 6px;
@@ -87,28 +92,36 @@ $flex_nav_breakpoint: 1100px;
     }
   }
 
-
   @media (min-width: $tablet-width) {
     display: flex;
     flex-direction: row;
+    div {
+      flex: 5;
     ul {
       display: flex;
       flex-direction: row;
-      flex: 5;
       li {
         position:relative;
         text-align: center;
         flex: 1;
       }
     }
+  }
     label {
       display:none;
+    }
+
+    .ticket__button__container {
+      position: initial;
+      flex: 1;
     }
   }
 
   @media (min-width: $desktop-width) {
+    div {
     ul {
       flex: 6;
     }
+  }
   }
 }

--- a/shared/components/NavigationBar/index.scss
+++ b/shared/components/NavigationBar/index.scss
@@ -1,7 +1,3 @@
-body {
-  background-color: $conference-color;
-}
-
 .NavigationBar {
   background-color: $grey;
   display: flex;
@@ -13,23 +9,21 @@ body {
       margin: 0;
       padding: 0;
       flex-direction: column;
-      li {
-        a {
-          padding: 14px 0px 14px 80px;
-          display: block;
-          font-weight: bold;
-          font-size: 18px;
-          color: $conference-color;
-          text-decoration: none;
-          &:hover {
-            background: $conference-color;
-            color: $grey;
-          }
-        }
-        a.active {
+      a {
+        padding: 14px 0px 14px 80px;
+        display: block;
+        font-weight: bold;
+        font-size: 18px;
+        color: $conference-color;
+        text-decoration: none;
+        &:hover {
           background: $conference-color;
           color: $grey;
         }
+      }
+      .active {
+        background: $conference-color;
+        color: $grey;
       }
     }
   }
@@ -125,7 +119,7 @@ body {
           a {
             padding-left: 0;
           }
-          a.active {
+          .active {
             color: white;
             background-color: $grey;
             border-bottom: 3px solid white;


### PR DESCRIPTION
# Motivation:
[Done in accordance with this ticket](https://trello.com/c/j6hQQVus/69-add-burger-navigation-menu)
The React.London community and conference pages have recently been split. This has resulted in some design changes including the removal of the navigation bar from the community page. The Navigation bar on the conference needs to be adapted to the complex requirements of the conference page.

The new navigation bar should look like [this](https://app.zeplin.io/project.html#pid=57adc4aaa7cbe69d4ad412a7&sid=57adc52d6e0610e306f6a5b3): 

<img width="1036" alt="screen shot 2016-08-15 at 14 04 38" src="https://cloud.githubusercontent.com/assets/6062416/17665194/40243296-62f1-11e6-9197-5bae55a0bdb9.png">

This navbar is to be responsive as seen [here](https://app.zeplin.io/project.html#pid=57adc4aaa7cbe69d4ad412a7&sid=57adc533b72a9aaa443c773c)

<img width="664" alt="screen shot 2016-08-15 at 14 05 27" src="https://cloud.githubusercontent.com/assets/6062416/17665208/5f51fe50-62f1-11e6-8c35-b7c0fef49b3e.png">