### PR TITLE
Minor text and button changes on community page

### DIFF
--- a/client/styles/main.scss
+++ b/client/styles/main.scss
@@ -17,6 +17,7 @@
 @import '../../shared/components/Speaker/index';
 @import '../../shared/components/MailingList/index';
 @import '../../shared/components/JoinSlack/index';
+@import '../../shared/components/InterestedSpeaker/index';
 @import '../../shared/components/Conference/index';
 @import '../../shared/components/ConferenceAbout/index';
 @import '../../shared/components/UpcomingEvents/index';

--- a/shared/components/Community/index.js
+++ b/shared/components/Community/index.js
@@ -7,6 +7,7 @@ import EventDetails from '../EventDetails';
 import NextCommunityEvent from '../../components/NextCommunityEvent';
 import MailingList from '../MailingList';
 import JoinSlack from '../JoinSlack';
+import InterestedSpeaker from '../InterestedSpeaker';
 import FutureEvents from '../FutureEvents';
 
 const usefulLinks = [
@@ -32,17 +33,18 @@ const Community = ({
       <RedBadgerBanner />
       <CommunityAbout summary={summary} />
       <NextCommunityEvent {...featuredEvent} />
-      <MailingList
-        mailingListTitle={mailingListTitle}
-        mailingListSummary={mailingListSummary}
-        page="community"
-      />
+      <InterestedSpeaker />
       <EventDetails
         eventSchedule={featuredEvent.schedule}
         eventSponsors={featuredEvent.sponsors}
       />
       <JoinSlack />
       <FutureEvents events={futureEvents} />
+      <MailingList
+        mailingListTitle={mailingListTitle}
+        mailingListSummary={mailingListSummary}
+        page="community"
+      />
       <SiteFooter page="Community" usefulLinks={usefulLinks} seriousLinks={seriousLinks} />
     </div>
   </div>

--- a/shared/components/InterestedSpeaker/index.js
+++ b/shared/components/InterestedSpeaker/index.js
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const InterestedSpeaker = () => (
+  <div className="InterestedSpeaker block">
+    <h3 className="InterestedSpeaker__heading">
+      Interested in becoming a speaker? Get in touch!
+    </h3>
+    <div className="content">
+      <a target="_blank" href="https://www.papercall.io/reactlondonmeetup" className="InterestedSpeaker__btn">Become a Speaker</a>
+    </div>
+  </div>
+);
+
+export default InterestedSpeaker;

--- a/shared/components/InterestedSpeaker/index.scss
+++ b/shared/components/InterestedSpeaker/index.scss
@@ -1,0 +1,35 @@
+.InterestedSpeaker {
+  background: $events-color;
+  text-align: center;
+  padding: 40px 0px;
+
+  &__text {
+    margin-top: 0px;
+    font-size: 20px;
+  }
+
+  &__heading {
+    font-size: 18px;
+    font-weight: normal;
+    margin-top: 0px;
+  }
+
+  &__btn {
+    border-radius: 6px;
+    border: 0px;
+    padding: 12px 20px 12px 20px;
+    color: $events-color;
+    font-weight: bold;
+    text-decoration: none;
+    background-color: $grey;
+    display: inline-block;
+
+    font-size: 20px;
+
+    &:focus,
+    &:hover {
+      color: $white;
+    }
+
+  }
+}

--- a/shared/components/InterestedSpeaker/test.js
+++ b/shared/components/InterestedSpeaker/test.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import InterestedSpeaker from '.';
+import { shallow } from 'enzyme';
+
+describe('InterestedSpeaker component', () => {
+  it('renders successfully', () => {
+    shallow(<InterestedSpeaker />);
+  });
+});

--- a/shared/components/MailingList/index.js
+++ b/shared/components/MailingList/index.js
@@ -37,7 +37,7 @@ const MailingList = ({ mailingListTitle, mailingListSummary, page }) => (
             <input
               className={'MailingList__form__submit MailingList__form__submit--' + page}
               type="submit"
-              value="Subscribe"
+              value="Get Updates"
               name="subscribe"
               id="mc-embedded-subscribe"
             />

--- a/shared/components/MailingList/index.scss
+++ b/shared/components/MailingList/index.scss
@@ -25,7 +25,7 @@
 
   // MAILCHIMP
   &__form__container {
-    width: 635px;
+    width: 650px;
   }
   &__form {
     font-size: 18px;
@@ -53,7 +53,7 @@
       background: $white;
       padding: 0px 15px;
 
-      max-width: 510px;
+      max-width: 500px;
       width: calc(100% - 140px); // 109px button width + 15px margin + 18px + 18px paddings removed.
     }
 

--- a/shared/components/NextCommunityEvent/index.js
+++ b/shared/components/NextCommunityEvent/index.js
@@ -22,16 +22,10 @@ function eventLocation(location) {
   return pathOr(placeholderText, ['address'], location);
 }
 
-function eventDate(date) {
-  if (date && date.iso) {
-    return formatDate(date, 'dddd, Do MMMM YYYY');
-  }
-  return placeholderText;
-}
-
-function eventTime(startDateTime, endDateTime) {
+function eventDateAndTime(startDateTime, endDateTime) {
   if (startDateTime && startDateTime.iso && endDateTime && endDateTime.iso) {
-    return formatDate(startDateTime, 'HH:mm - ') + formatDate(endDateTime, 'HH:mm');
+    return formatDate(startDateTime, 'dddd, Do MMMM YYYY | HH:mm - ')
+      + formatDate(endDateTime, 'HH:mm');
   }
   return placeholderText;
 }
@@ -75,16 +69,7 @@ const NextCommunityEvent = (featuredEvent) => {
                   href={calendarURL}
                   target="_blank"
                 >
-                  {eventDate(startDateTime)}
-                </a>
-              </li>
-              <li>
-                <a
-                  className="NextCommunityEvent__link--time"
-                  href={calendarURL}
-                  target="_blank"
-                >
-                  {eventTime(startDateTime, endDateTime)}
+                  {eventDateAndTime(startDateTime, endDateTime)}
                 </a>
               </li>
               <li>

--- a/shared/components/NextCommunityEvent/index.js
+++ b/shared/components/NextCommunityEvent/index.js
@@ -52,7 +52,7 @@ export function getHeaderText(startDateTime, endDateTime) {
   }
 
   if (!isToday && isBefore(currentDateTime, startDateTime.iso)) {
-    return 'Next Event';
+    return 'Next Meetup';
   }
 }
 

--- a/shared/components/NextCommunityEvent/test.js
+++ b/shared/components/NextCommunityEvent/test.js
@@ -89,7 +89,7 @@ describe('getHeaderText', () => {
       { iso: new Date('2016-07-26T17:30:00+0000') },
       { iso: new Date('2016-07-26T19:30:00+0000') }
     );
-    expect(result).to.equal('Next Event');
+    expect(result).to.equal('Next Meetup');
   });
 
   it('returns Community Event if no props are passed', () => {

--- a/shared/components/NextCommunityEvent/test.js
+++ b/shared/components/NextCommunityEvent/test.js
@@ -25,9 +25,7 @@ describe('NextCommunityEvent component', () => {
   it('renders OK with all props', () => {
     const elem = shallow(<NextCommunityEvent {...fullProps} />);
     const dateText = elem.find('.NextCommunityEvent__link--date').text();
-    expect(dateText).to.equal('Tuesday, 26th July 2016');
-    const timeText = elem.find('.NextCommunityEvent__link--time').text();
-    expect(timeText).to.equal('18:30 - 21:30');
+    expect(dateText).to.equal('Tuesday, 26th July 2016 | 18:30 - 21:30');
     const locText = elem.find('.NextCommunityEvent__link--place').text();
     expect(locText).to.equal(fullProps.location.address);
   });
@@ -46,21 +44,6 @@ describe('NextCommunityEvent component', () => {
       const dateText = elem.find('.NextCommunityEvent__link--date').text();
       expect(dateText).to.equal(placeholderText,
         'Should display default date without prop ' + path.join('.'));
-    });
-  });
-
-  it('has default value for the time', () => {
-    [
-      ['startDateTime'],
-      ['startDateTime', 'iso'],
-      ['endDateTime'],
-      ['endDateTime', 'iso'],
-    ].forEach(path => {
-      const props = R.dissocPath(path, fullProps);
-      const elem = shallow(<NextCommunityEvent {...props} />);
-      const dateText = elem.find('.NextCommunityEvent__link--time').text();
-      expect(dateText).to.equal(placeholderText,
-        'Should display default time without prop ' + path.join('.'));
     });
   });
 

--- a/shared/components/TicketStatus/index.js
+++ b/shared/components/TicketStatus/index.js
@@ -31,9 +31,9 @@ const TicketStatus = (props) => {
       </p>
       <StatusButton {...props} />
       <p className="TicketStatus__live-stream-text">
-        To get reminders about tickets and future
+        Get event updates and reminders
         events <a className="TicketStatus__live-stream-text--link" href="#stay-tuned">
-        subscribe here</a>
+        below</a>
       </p>
     </div>
   );

--- a/shared/utilities/ticket-status/index.js
+++ b/shared/utilities/ticket-status/index.js
@@ -50,7 +50,7 @@ function defaultValues() {
 export function isTicketPreRelease({ currentTime, ticketReleaseDate }) {
   if (isBefore(currentTime, ticketReleaseDate)) {
     return {
-      buttonText: 'Free Ticket',
+      buttonText: 'FREE TICKET AVAILABLE SOON',
       linkType: '',
       statusHeader: 'TICKETS WILL GO LIVE ON',
       statusSubHeader: formatDate(ticketReleaseDate, 'dddd, Do MMMM YYYY, HH:mm'),

--- a/shared/utilities/ticket-status/test.js
+++ b/shared/utilities/ticket-status/test.js
@@ -10,7 +10,7 @@ describe('getTicketStatusOptions', () => {
       const result = getTicketStatusOptions({ ticketReleaseDate });
 
       expect(result).to.deep.equal({
-        buttonText: 'Free Ticket',
+        buttonText: 'FREE TICKET AVAILABLE SOON',
         linkType: '',
         statusHeader: 'TICKETS WILL GO LIVE ON',
         statusSubHeader: 'Thursday, 1st January 1970, 01:00',


### PR DESCRIPTION
# Motivation
[Trello Ticket](https://trello.com/c/2qTfEsJR/60-update-content-for-new-community-site)

There are numerous text tweaks that are required for the community page. An annotated diagram can be seen in the ticket link above. 

The list of changes are: 

- [x]  Remove Badger (done in previous ticket by @lpil)
- [x]  Remove Tabs (done in previous ticket by @lpil)
- [x]  Rename 'Next Event' to 'Next Meetup'
- [x]  Move time to same line as event date
- [x]  Change text to 'FREE TICKET AVAILABLE SOON' when tickets are not available 
- [x]  Change the 'To get reminders about...' text to 'Get event updates and reminders below and remove the anchor
- [x]  Move 'Get Updates' block above the footer'
- [x]  Change 'Subscribe' to 'Get Updates' in the mailing list block
- [x]  Add link to papercall
- [x]  For Intro from 'Stu' link to his personal profile (Will be done in another ticket - Roisi)
 