### PR TITLE
Use local paths for banner links

### DIFF
--- a/shared/components/SiteFooter/index.js
+++ b/shared/components/SiteFooter/index.js
@@ -22,7 +22,7 @@ function Banner({ page }) {
             We&rsquo;re launching a new conference<br />focused on React
           </span>
         </p>
-        <a className="SiteFooter__banner-cta" href="https://react.london/">
+        <a className="SiteFooter__banner-cta" href="/conference">
           <span className="text-background">
             Find out more
           </span>
@@ -40,7 +40,7 @@ function Banner({ page }) {
           Looking for our meetups?
         </span>
       </p>
-      <a className="SiteFooter__banner-cta" href="https://meetup.react.london/">
+      <a className="SiteFooter__banner-cta" href="/community">
         <span className="text-background">
           Find out more
         </span>


### PR DESCRIPTION
The banners used to link to absolute URLs, so you would be thrown out of your staging / dev environment and into production.

The PR now links the banners to `/community` and `/conference`, which then redirect to the correct URL for the environment you are in.