### PR TITLE
Ticketlist - replacing flexbox with percents

### DIFF
--- a/shared/components/TicketList/index.scss
+++ b/shared/components/TicketList/index.scss
@@ -78,13 +78,12 @@
     &__ticket {
       display: table-row;
       border-bottom: none;
-      display: flex;
       padding: 0px;
       td {
         display: table-cell;
         border-bottom: $dash-border;
         padding: 30px 0px;
-        flex: 1;
+        width: 33%;
       }
       td:nth-child(2) {
         text-align: center;


### PR DESCRIPTION
for #183 
in IE11 - 
![ie11-ticketlist](https://cloud.githubusercontent.com/assets/5781504/18163737/5fa5a1cc-7034-11e6-9372-6b034c7bc8b7.png)

I am aware there's a bit of a weird spacing thing at this screen size:
<img width="515" alt="screen shot 2016-09-01 at 11 04 26" src="https://cloud.githubusercontent.com/assets/5781504/18163762/7b5d63e6-7034-11e6-8339-3bdf3c2c0eb0.png">
but this is due to the text-align right on the right hand div, which makes the center text appear not centered.

