### PR TITLE
Added css to check for empty hrefs and adjust links accordingly

### DIFF
--- a/shared/components/NextCommunityEvent/index.scss
+++ b/shared/components/NextCommunityEvent/index.scss
@@ -34,11 +34,15 @@
     background: url("/img/SVG/Date_icon_green.svg") no-repeat left top;
     height: 26px;
     padding-top: 2px;
+    pointer-events: none;
 
-    &:focus,
-    &:hover {
-      background-image: url("/img/SVG/Date_icon_white.svg");
-      text-decoration: underline;
+    &[href^="http"] {
+      pointer-events: all;
+      &:focus,
+      &:hover {
+        background-image: url("/img/SVG/Date_icon_white.svg");
+        text-decoration: underline;
+      }
     }
   }
 
@@ -46,11 +50,15 @@
     background: url("/img/SVG/Place_icon_green.svg") no-repeat 0px 1px;
     height: 32px;
     padding-top: 5px;
+    pointer-events: none;
 
-    &:focus,
-    &:hover {
-      background-image: url("/img/SVG/Place_icon_white.svg");
-      text-decoration: underline;
+    &[href^="http"] {
+      pointer-events: all;
+      &:focus,
+      &:hover {
+        background-image: url("/img/SVG/Place_icon_white.svg");
+        text-decoration: underline;
+      }
     }
   }
 
@@ -58,11 +66,15 @@
     background: url("/img/SVG/Time_icon_green.svg") no-repeat left top;
     height: 25px;
     padding-top: 3px;
+    pointer-events: none;
 
-    &:focus,
-    &:hover {
-      background-image: url("/img/SVG/Time_icon_white.svg");
-      text-decoration: underline;
+    &[href^="http"] {
+      pointer-events: all;
+      &:focus,
+      &:hover {
+        background-image: url("/img/SVG/Time_icon_white.svg");
+        text-decoration: underline;
+      }
     }
   }
 

--- a/shared/components/NextConferenceEvent/index.scss
+++ b/shared/components/NextConferenceEvent/index.scss
@@ -10,18 +10,20 @@
     color: $conference-color-faded;
     font-weight: bold;
     text-decoration: none;
-
     display: inline-block;
     background: url("/img/SVG/G_blue.svg") no-repeat 17px 12px $grey;
     background-size: 22px 22px;
     font-size: 16px;
+    pointer-events: none;
 
-    &:focus,
-    &:hover {
-      color: $white;
-      background-image: url("/img/SVG/G_white.svg");
+    &[href^="http"] {
+      pointer-events: all;
+      &:focus,
+      &:hover {
+        color: $white;
+        background-image: url("/img/SVG/G_white.svg");
+      }
     }
-
   }
 
   &__save-the-date,
@@ -69,11 +71,14 @@
     background: url("/img/SVG/Date_icon_blue.svg") no-repeat left top;
     height: 26px;
     padding-top: 2px;
-
-    &:focus,
-    &:hover {
-      background-image: url("/img/SVG/Date_icon_white.svg");
-      text-decoration: underline;
+    pointer-events: none;
+    &[href^="http"] {
+      pointer-events: all;
+      &:focus,
+      &:hover {
+        background-image: url("/img/SVG/Date_icon_white.svg");
+        text-decoration: underline;
+      }
     }
   }
 
@@ -81,11 +86,15 @@
     background: url("/img/SVG/Place_icon_blue.svg") no-repeat 0px 1px;
     height: 32px;
     padding-top: 5px;
+    pointer-events: none;
 
-    &:focus,
-    &:hover {
-      background-image: url("/img/SVG/Place_icon_white.svg");
-      text-decoration: underline;
+    &[href^="http"] {
+      pointer-events: all;
+      &:focus,
+      &:hover {
+        background-image: url("/img/SVG/Place_icon_white.svg");
+        text-decoration: underline;
+      }
     }
   }
 
@@ -96,10 +105,15 @@
     padding-top: 10px;
     margin-top: 7px;
     max-width: 15em;
+    pointer-events: none;
 
-    &:focus,
-    &:hover {
-      background-image: url("/img/SVG/Save_the_date_icon_white.svg");
+    &[href^="http"] {
+      pointer-events: all;
+      &:focus,
+      &:hover {
+        background-image: url("/img/SVG/Save_the_date_icon_white.svg");
+        text-decoration: underline;
+      }
     }
   }
 


### PR DESCRIPTION
![Alt Text](https://media.giphy.com/media/ShRCrEwaIJUkM/giphy.gif)

## Motivation

Upon a further review, the great @lpil discovered that, if the calendar links have no link provided on Prismic they still have the same hover state and link react.london. This behaviour is, well, undesirable.

So dear reviewer, I have to change my stance (hatred) of css upon finding this lovely snippet:

```
&[href^="http"] {
    //css here
}
```

This selects for elements which have an href, and an href that starts with "http". My goodness. 

So I added this styling on our calendar/map links on both the community and conference sites.

Thanks for the review!
