### PR TITLE
Added External Link component with logic for empty links

### DIFF
--- a/shared/components/ExternalLink/index.js
+++ b/shared/components/ExternalLink/index.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 
 export const ExternalLink = (props) => {
-  const linkProps = Object.assign({}, props); // This is done as the props are not mutable
+  const linkProps = { ...props }; // This is done as the props are not mutable
   if (!linkProps.href) {
     delete linkProps.href;
   }

--- a/shared/components/ExternalLink/index.js
+++ b/shared/components/ExternalLink/index.js
@@ -1,0 +1,18 @@
+import React, { PropTypes } from 'react';
+
+export const ExternalLink = (props) => {
+  const linkProps = Object.assign({}, props); // This is done as the props are not mutable
+  if (!linkProps.href) {
+    delete linkProps.href;
+  }
+  if (linkProps.href && linkProps.href.substring(0, 4) !== 'http') {
+    linkProps.href = 'http://' + linkProps.href;
+  }
+  return (
+    <a {...linkProps} target="_blank" rel="noopener">{props.children}</a>
+  );
+};
+
+ExternalLink.propTypes = {
+  children: PropTypes.string.isRequired,
+};

--- a/shared/components/ExternalLink/test.js
+++ b/shared/components/ExternalLink/test.js
@@ -1,0 +1,37 @@
+
+import React from 'react';
+import { ExternalLink } from '.';
+import { shallow } from 'enzyme';
+
+describe('ExternalLink component', () => {
+  it('renders OK with all props', () => {
+    const fullProps = {
+      href: 'http://www.google.com',
+      children: 'Example Text',
+    };
+    const elem = shallow(<ExternalLink {...fullProps} />);
+    const dateElement = elem.find('a');
+    expect(dateElement.props().href).to.equal(fullProps.href);
+    expect(dateElement.text()).to.equal('Example Text');
+  });
+
+  it('renders without a href if no href is passed', () => {
+    const props = {
+      children: 'Example Text',
+    };
+    const elem = shallow(<ExternalLink {...props} />);
+    const dateElement = elem.find('a');
+    expect(dateElement.props().href).to.equal(undefined);
+  });
+
+  it('it adds http:// infront of an href if it does not already contain it', () => {
+    const props = {
+      children: 'Example Text',
+      href: 'google.com',
+    };
+    const elem = shallow(<ExternalLink {...props} />);
+    const dateElement = elem.find('a');
+    expect(dateElement.props().href).to.equal('http://' + props.href);
+  });
+});
+

--- a/shared/components/NextCommunityEvent/index.js
+++ b/shared/components/NextCommunityEvent/index.js
@@ -7,7 +7,7 @@ import { formatDate, isBefore, isAfter } from '../../utilities/date';
 import pathOr from 'ramda/src/pathOr';
 import moment from 'moment';
 import { getTicketStatusOptions } from '../../utilities/ticket-status';
-
+import { ExternalLink } from '../ExternalLink';
 export const placeholderText = 'To be confirmed.';
 
 function eventLocation(location) {
@@ -56,24 +56,22 @@ const NextCommunityEvent = (featuredEvent) => {
             <h3 className="NextCommunityEvent__details__heading">{title}</h3>
             <ul className="NextCommunityEvent__details">
               <li>
-                <a
-                  className="NextCommunityEvent__link--date"
+                <ExternalLink
                   href={calendarURL}
-                  target="_blank"
-                  rel="noopener"
+                  className="NextCommunityEvent__link--date"
                 >
                   {eventDateAndTime(startDateTime, endDateTime)}
-                </a>
+                </ExternalLink>
               </li>
               <li>
-                <a
+                <ExternalLink
                   className="NextCommunityEvent__link--place"
                   href={googleMapsUrl(location)}
                   target="_blank"
                   rel="noopener"
                 >
                   {eventLocation(location)}
-                </a>
+                </ExternalLink>
               </li>
             </ul>
           </div>

--- a/shared/components/NextCommunityEvent/index.scss
+++ b/shared/components/NextCommunityEvent/index.scss
@@ -34,11 +34,12 @@
     background: url("/img/SVG/Date_icon_green.svg") no-repeat left top;
     height: 26px;
     padding-top: 2px;
-
-    &:focus,
-    &:hover {
-      background-image: url("/img/SVG/Date_icon_white.svg");
-      text-decoration: underline;
+    &[href]{
+      &:focus,
+      &:hover {
+        background-image: url("/img/SVG/Date_icon_white.svg");
+        text-decoration: underline;
+      }
     }
   }
 
@@ -47,10 +48,12 @@
     height: 32px;
     padding-top: 5px;
 
-    &:focus,
-    &:hover {
-      background-image: url("/img/SVG/Place_icon_white.svg");
-      text-decoration: underline;
+    &[href]{
+      &:focus,
+      &:hover {
+        background-image: url("/img/SVG/Place_icon_white.svg");
+        text-decoration: underline;
+      }
     }
   }
 
@@ -59,10 +62,12 @@
     height: 25px;
     padding-top: 3px;
 
-    &:focus,
-    &:hover {
-      background-image: url("/img/SVG/Time_icon_white.svg");
-      text-decoration: underline;
+    &[href]{
+      &:focus,
+      &:hover {
+        background-image: url("/img/SVG/Time_icon_white.svg");
+        text-decoration: underline;
+      }
     }
   }
 

--- a/shared/components/NextCommunityEvent/test.js
+++ b/shared/components/NextCommunityEvent/test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import NextCommunityEvent, { placeholderText, getHeaderText } from '.';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import tk from 'timekeeper';
 import R from 'ramda';
 
@@ -24,7 +24,7 @@ const fullProps = {
 
 describe('NextCommunityEvent component', () => {
   it('renders OK with all props', () => {
-    const elem = shallow(<NextCommunityEvent {...fullProps} />);
+    const elem = mount(<NextCommunityEvent {...fullProps} />);
     const dateElement = elem.find('.NextCommunityEvent__link--date');
     expect(dateElement.text()).to.equal('Tuesday, 26th July 2016, 18:30 – 21:30');
     expect(dateElement.props().href).to.equal('http://www.google.com/cal');
@@ -33,7 +33,7 @@ describe('NextCommunityEvent component', () => {
   });
 
   it('renders without crashing when passed no props', () => {
-    shallow(<NextCommunityEvent />);
+    mount(<NextCommunityEvent />);
   });
 
   it('has default value for missing the date', () => {
@@ -42,7 +42,7 @@ describe('NextCommunityEvent component', () => {
       ['startDateTime', 'iso'],
     ].forEach(path => {
       const props = R.dissocPath(path, fullProps);
-      const elem = shallow(<NextCommunityEvent {...props} />);
+      const elem = mount(<NextCommunityEvent {...props} />);
       const dateText = elem.find('.NextCommunityEvent__link--date').text();
       expect(dateText).to.equal(placeholderText,
         'Should display default date without prop ' + path.join('.'));
@@ -55,7 +55,7 @@ describe('NextCommunityEvent component', () => {
       ['location', 'address'],
     ].forEach(path => {
       const props = R.dissocPath(path, fullProps);
-      const elem = shallow(<NextCommunityEvent {...props} />);
+      const elem = mount(<NextCommunityEvent {...props} />);
       const dateText = elem.find('.NextCommunityEvent__link--place').text();
       expect(dateText).to.equal(placeholderText,
         'Should display default location without prop ' + path.join('.'));

--- a/shared/components/NextConferenceEvent/index.js
+++ b/shared/components/NextConferenceEvent/index.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import { ExternalLink } from '../ExternalLink';
 
 const locationURL = 'https://goo.gl/maps/GkqTFrJKaUR2';
 
@@ -12,24 +13,20 @@ const NextConferenceEvent = ({ calendarURL }) => (
           </h3>
           <ul>
             <li>
-              <a
+              <ExternalLink
                 className="NextConferenceEvent__link--date"
                 href={calendarURL}
-                target="_blank"
-                rel="noopener"
               >
                 Tuesday, 28 March 2017
-              </a>
+              </ExternalLink>
             </li>
             <li>
-              <a
+              <ExternalLink
                 className="NextConferenceEvent__link--place"
                 href={locationURL}
-                target="_blank"
-                rel="noopener"
               >
                 QEII Centre, Westminster
-              </a>
+              </ExternalLink>
             </li>
           </ul>
         </div>
@@ -40,14 +37,12 @@ const NextConferenceEvent = ({ calendarURL }) => (
           <h3>
             Save the date
           </h3>
-          <a
+          <ExternalLink
             className="NextConferenceEvent__btn"
             href={calendarURL}
-            target="_blank"
-            rel="noopener"
           >
             Add to calendar
-          </a>
+          </ExternalLink>
         </div>
       </article>
     </div>

--- a/shared/components/NextConferenceEvent/index.scss
+++ b/shared/components/NextConferenceEvent/index.scss
@@ -16,12 +16,13 @@
     background-size: 22px 22px;
     font-size: 16px;
 
-    &:focus,
-    &:hover {
-      color: $white;
-      background-image: url("/img/SVG/G_white.svg");
+    &[href]{
+      &:focus,
+      &:hover {
+        color: $white;
+        background-image: url("/img/SVG/G_white.svg");
+      }
     }
-
   }
 
   &__save-the-date,
@@ -70,10 +71,12 @@
     height: 26px;
     padding-top: 2px;
 
-    &:focus,
-    &:hover {
-      background-image: url("/img/SVG/Date_icon_white.svg");
-      text-decoration: underline;
+    &[href]{
+      &:focus,
+      &:hover {
+        background-image: url("/img/SVG/Date_icon_white.svg");
+        text-decoration: underline;
+      }
     }
   }
 
@@ -82,10 +85,12 @@
     height: 32px;
     padding-top: 5px;
 
-    &:focus,
-    &:hover {
-      background-image: url("/img/SVG/Place_icon_white.svg");
-      text-decoration: underline;
+    &[href]{
+      &:focus,
+      &:hover {
+        background-image: url("/img/SVG/Place_icon_white.svg");
+        text-decoration: underline;
+      }
     }
   }
 
@@ -97,9 +102,11 @@
     margin-top: 7px;
     max-width: 15em;
 
-    &:focus,
-    &:hover {
-      background-image: url("/img/SVG/Save_the_date_icon_white.svg");
+    &[href]{
+      &:focus,
+      &:hover {
+        background-image: url("/img/SVG/Save_the_date_icon_white.svg");
+      }
     }
   }
 


### PR DESCRIPTION
![Alt Text](https://media.giphy.com/media/yrhgvtibXMVX2/giphy.gif)

## Motivation

The great @lpil discovered that, if the calendar links have no link provided on Prismic they still have the same hover state and link react.london. 

This was fixed in this [PR](https://github.com/redbadger/react.london/pull/225) but, even though I attempted to not use yavascript at all, some yavascript was required.

Not to fear dear reader, I only write simple yavascript! I created a simple component called 'ExternalLink'. This component is passed is passed a className and href. If the href does not exist, it is not passed through to the link. If the href exists but does not include http, this is added. If it does exist, well, business as usual.

![Alt Text](https://media.giphy.com/media/OujS6Ni1ijOV2/giphy.gif)

 Don't be bored dear reader, to keep you motivated I have included a second gif!

![Alt Text](https://media.giphy.com/media/dgxzWSlRjSuyI/giphy.gif)

But how do we let the css know that the link has no link so there are no hover/active states? Look at this:

```
&[href] {
    //css here
}
```

This selects for elements which have an href, and an href that starts with "http". Isn't that simply marvellous?

![Alt Text](https://media.giphy.com/media/3o6ZtnOHOyPiSHwXpm/giphy.gif)
