### PR TITLE
Using react-ga so we can see people moving around the site

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -6,19 +6,34 @@ import communityRoutes from '../shared/routes/community-routes';
 import conferenceRoutes from '../shared/routes/conference-routes';
 import isMeetupRequest from '../shared/utilities/meetup-request';
 
+import * as ReactGA from 'react-ga';
+ReactGA.initialize('UA-16654919-5');
+
 const initialState = window.__INITIAL_STATE__;
 
 let components;
 
+const routerUpdate = () => {
+  ReactGA.set({ page: window.location.pathname });
+  ReactGA.pageview(window.location.pathname);
+};
+
 if (isMeetupRequest(window.location)) {
   components = (
-    <Router history={browserHistory}>
+    <Router
+      history={browserHistory}
+      onUpdate={routerUpdate}
+    >
       {communityRoutes(initialState)}
     </Router>
   );
 } else {
   components = (
-    <Router history={browserHistory} render={applyRouterMiddleware(useScroll())}>
+    <Router
+      history={browserHistory}
+      render={applyRouterMiddleware(useScroll())}
+      onUpdate={routerUpdate}
+    >
       {conferenceRoutes(initialState)}
     </Router>
   );

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "raven": "^0.12.1",
     "react": "^15.0.1",
     "react-dom": "^15.0.1",
+    "react-ga": "^2.1.1",
     "react-router": "^2.5.2",
     "react-router-scroll": "^0.3.2",
     "sass-loader": "^3.2.1",

--- a/server/views/index.pug
+++ b/server/views/index.pug
@@ -37,15 +37,3 @@ html
       script(type='text/javascript').
         window.__INITIAL_STATE__ = !{JSON.stringify(initialState)}
       script(src="/static/main.js")
-
-    script(type="text/javascript").
-      var _gaq = _gaq || [];
-      _gaq.push(['_setAccount', 'UA-16654919-5']);
-      _gaq.push(['_trackPageview']);
-      (function() {
-        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-      })();
-
-


### PR DESCRIPTION
Google Analytics only registers when people first load the site, not when they move around. React-ga fixes this so it properly picks up multiple pages

Tested by checking the network tab - I can see GA's .gif thing on each page click.

Code lifted from https://github.com/redbadger/website-next/pull/193/files thanks @asavin !

![](http://i.giphy.com/sNz7ODDP6lsRy.gif)