### PR TITLE
Prismic cleaning

### DIFF
--- a/server/community-data/index.js
+++ b/server/community-data/index.js
@@ -1,12 +1,12 @@
 const MAX_EVENTS = 3;
 
 function featuredEvent(events) {
-  return events.find(e => e.displayLevel === 'Featured') || {};
+  return events.find(e => e.displayLevel === 'Featured' || e.displayLevel === 'Current') || {};
 }
 
 function futureEvents(events) {
   return events
-    .filter(e => e.displayLevel === 'Highlighted')
+    .filter(e => e.displayLevel === 'Highlighted' || e.displayLevel === 'Upcoming')
     .slice(0, MAX_EVENTS);
 }
 

--- a/server/community-data/test.js
+++ b/server/community-data/test.js
@@ -42,8 +42,20 @@ describe('community-data transform', () => {
         title: '3', displayLevel: 'Featured',
       });
     });
+    it('selects a the next event with a Current displayLevel', () => {
+      const events = [
+        { title: '1', displayLevel: 'Regular' },
+        { title: '2', displayLevel: 'Highlighted' },
+        { title: '3', displayLevel: 'Current' },
+      ];
+      const data = { community: { ...fixture.community, events } };
+      const state = communityData(data);
+      expect(state.featuredEvent).to.deep.equal({
+        title: '3', displayLevel: 'Current',
+      });
+    });
 
-    it('defaults to {} with no event with a Featured displayLevel', () => {
+    it('defaults to {} with no event with a Featured or Current displayLevel', () => {
       const events = [
         { title: '1', displayLevel: 'Regular' },
         { title: '2', displayLevel: 'Highlighted' },
@@ -72,6 +84,25 @@ describe('community-data transform', () => {
         { title: '2', displayLevel: 'Highlighted' },
         { title: '3', displayLevel: 'Highlighted' },
         { title: '4', displayLevel: 'Highlighted' },
+      ]);
+    });
+    it('selects the first 3 Upcoming events', () => {
+      const events = deepFreeze([
+        { title: '1', displayLevel: 'Regular' },
+        { title: '2', displayLevel: 'Upcoming' },
+        { title: '3', displayLevel: 'Featured' },
+        { title: '3', displayLevel: 'Upcoming' },
+        { title: '4', displayLevel: 'Upcoming' },
+        { title: '5', displayLevel: 'Featured' },
+        { title: '6', displayLevel: 'Upcoming' },
+        { title: '7', displayLevel: 'Upcoming' },
+      ]);
+      const data = { community: { ...fixture.community, events } };
+      const state = communityData(data);
+      expect(state.futureEvents).to.deep.equal([
+        { title: '2', displayLevel: 'Upcoming' },
+        { title: '3', displayLevel: 'Upcoming' },
+        { title: '4', displayLevel: 'Upcoming' },
       ]);
     });
 

--- a/server/data/badger-brain.js
+++ b/server/data/badger-brain.js
@@ -21,8 +21,6 @@ query {
     events {
       title
       eventType
-      ticketsAvailable
-      waitingListOpen
       displayLevel
       calendarURL
       status

--- a/shared/components/TicketStatus/test.js
+++ b/shared/components/TicketStatus/test.js
@@ -3,7 +3,6 @@ import TicketStatus, { StatusButton } from '.';
 import { shallow } from 'enzyme';
 
 const props = {
-  ticketsAvailable: true,
   externalLinks: [
     {
       title: 'foo baz',

--- a/test/fixtures/badger-brain-payload.json
+++ b/test/fixtures/badger-brain-payload.json
@@ -9,8 +9,6 @@
         {
           "title": "React London Meetup July 2016",
           "eventType": "Featured",
-          "ticketsAvailable": false,
-          "waitingListOpen": false,
           "displayLevel": "Featured",
           "calendarURL": "http://www.google.com",
           "startDateTime": {
@@ -109,8 +107,6 @@
         {
           "title": "August React London Meetup",
           "eventType": null,
-          "ticketsAvailable": false,
-          "waitingListOpen": false,
           "displayLevel": "Highlighted",
           "calendarURL": "http://www.google.com",
           "startDateTime": {


### PR DESCRIPTION
#  The Prismic cleaning process 

## Prismic don't wanna be cleaned
![Alt Text](https://media.giphy.com/media/fpXxIjftmkk9y/giphy.gif)
![Alt Text](https://media.giphy.com/media/GfXFVHUzjlbOg/giphy.gif)

## Prismic don't have no choice
![Alt Text](https://media.giphy.com/media/1E2YvBpiOMFWM/giphy.gif)
![Alt Text](https://media.giphy.com/media/OsVHDytNJNQ7m/giphy.gif)

## Code Walkthrough
- I remove ticketsAvailable and waitingListOpen because they have been banished.
- I now accommodate Current and Upcoming event display levels as Featured, Highlighted and Regular display levels are being phased out. This is a two step process.