### PR TITLE
Fixing Speakers page header style

### DIFF
--- a/shared/components/SpeakersPage/index.scss
+++ b/shared/components/SpeakersPage/index.scss
@@ -9,7 +9,7 @@
 
 .speakers-list-intro {
   max-width: $maximum-content-width;
-  margin: 0 auto 40px;
+  margin: 0 40px 40px;
 }
 
 .no-cfp-announcement {
@@ -21,5 +21,12 @@
     max-width: $maximum-content-width;
     margin: 0 auto;
     font-size: 20px;
+  }
+}
+
+@media (min-width: $tablet-width) {
+  .speakers-list-intro {
+    margin: 0 auto 40px;
+    padding-left: 20px;
   }
 }


### PR DESCRIPTION
![giphy 5](https://cloud.githubusercontent.com/assets/487468/18582479/51052a5a-7bfd-11e6-9291-45b85afcfd49.gif)

Adjusting padding of the page header

<img width="125" alt="react_london_and_alex_badgeras____red-badger_react_london__zsh_" src="https://cloud.githubusercontent.com/assets/487468/18582509/7d631990-7bfd-11e6-8ec6-77f71e28f93a.png">
