### PR TITLE
Changing level labels for sponsors

### DIFF
--- a/shared/components/ConferencePartners/index.js
+++ b/shared/components/ConferencePartners/index.js
@@ -31,19 +31,19 @@ const ConferencePartners = (props) => {
 
       <PartnersSection
         partners={gold || []}
-        title="Gold partners"
+        title="Pioneer partners"
         level="gold"
       />
 
       <PartnersSection
         partners={silver || []}
-        title="Silver partners"
+        title="Explorer partners"
         level="silver"
       />
 
       <PartnersSection
         partners={stripDescription(bronze)}
-        title="Bronze partners"
+        title="Trekker partners"
         level="bronze"
       />
 


### PR DESCRIPTION
Mapping bronze-silver-gold levels to be printed out as trekker-explorer-pioneer sponsor levels.