### PR TITLE
Removing sponsor level labels except for Supporters

### DIFF
--- a/shared/components/ConferencePartners/index.js
+++ b/shared/components/ConferencePartners/index.js
@@ -31,19 +31,16 @@ const ConferencePartners = (props) => {
 
       <PartnersSection
         partners={gold || []}
-        title="Pioneer partners"
         level="gold"
       />
 
       <PartnersSection
         partners={silver || []}
-        title="Explorer partners"
         level="silver"
       />
 
       <PartnersSection
         partners={stripDescription(bronze)}
-        title="Trekker partners"
         level="bronze"
       />
 

--- a/shared/components/ConferencePartners/index.scss
+++ b/shared/components/ConferencePartners/index.scss
@@ -39,7 +39,7 @@
 
 .InterestedPartner {
   border-top: $solid-border;
-  background: $conference-color;
+  background: $conference-color-faded;
   text-align: center;
   padding: 40px 0px;
 }

--- a/shared/components/PartnersSection/index.js
+++ b/shared/components/PartnersSection/index.js
@@ -20,12 +20,15 @@ Partner.propTypes = partnerType;
 const PartnersSection = ({ partners, level, title }) => {
   if (!Array.isArray(partners) || !partners.length > 0) { return null; }
   return (
-    <section className={'block PartnersSection__' + level}>
-      <div className="content">
-        <h3 className="PartnersSection__title">
-          {title}
-        </h3>
-      </div>
+    <section className={'block PartnersSectionContainer PartnersSection__' + level}>
+      {
+        title &&
+          <div className="content">
+            <h3 className="PartnersSection__title">
+              {title}
+            </h3>
+          </div>
+      }
 
       <ul className="content PartnersSection__list">
         {partners.map((partner, index) =>
@@ -38,7 +41,7 @@ const PartnersSection = ({ partners, level, title }) => {
 PartnersSection.propTypes = {
   partners: PropTypes.arrayOf(PropTypes.shape(Partner.propTypes)),
   level: PropTypes.string.isRequired,
-  title: PropTypes.string.isRequired,
+  title: PropTypes.string,
 };
 
 export default PartnersSection;

--- a/shared/components/PartnersSection/index.scss
+++ b/shared/components/PartnersSection/index.scss
@@ -1,3 +1,11 @@
+.PartnersSectionContainer {
+  padding-top: 40px;
+
+  &.PartnersSection__supporters {
+    padding-top: 0;
+  }
+}
+
 .PartnersSection__title {
   font-size: 24px;
   margin: 0px;


### PR DESCRIPTION
Keeping supporters title on Partners page of the conference, but removing sponsor level titles for all bronze-silver-gold levels.