### PR TITLE
Deactivated 'Call for papers' and 'Become a speaker' links

### DIFF
--- a/shared/components/SchedulePageOverview/index.js
+++ b/shared/components/SchedulePageOverview/index.js
@@ -22,16 +22,19 @@ const SchedulePageOverview = (props) => {
             </div>
           </div>
           <div className="SchedulePageOverview__cfp">
-            <a
-              href="https://www.papercall.io/reactlondon2017"
+            <span
               className="SchedulePageOverview__button"
-              target="_blank"
-              rel="noopener"
             >
-              Call for papers
-            </a>
+              Call for papers closed
+            </span>
             <div>
-              Closes 31 Jan
+              Too late? Talk at our monthly <a
+                href="/community"
+                target="_blank"
+                rel="noopener"
+              >
+                React meetup
+              </a>
             </div>
           </div>
         </div>
@@ -45,4 +48,3 @@ SchedulePageOverview.propTypes = {
 };
 
 export default SchedulePageOverview;
-

--- a/shared/components/SchedulePageOverview/index.scss
+++ b/shared/components/SchedulePageOverview/index.scss
@@ -21,6 +21,13 @@
   &__cfp {
     text-align: left;
     padding-bottom: 40px;
+
+    a {
+      color: inherit;
+      &:hover {
+        color: $middle-grey;
+      }
+    }
   }
 
   &__date {
@@ -38,9 +45,9 @@
     border: 0;
     padding: 12px 20px;
     font-weight: 700;
-    background-color: #fc1d42;
+    background-color: $disabled-grey;
     text-decoration: none;
-    color: #fff;
+    color: $conference-color-faded;
     display: inline-block;
     font-size: 16px;
     margin-bottom: 10px;
@@ -72,5 +79,3 @@
     }
   }
 }
-
-

--- a/shared/components/SpeakerPagePlaceholder/index.js
+++ b/shared/components/SpeakerPagePlaceholder/index.js
@@ -1,24 +1,11 @@
 import React from 'react';
-import { ExternalLink } from '../ExternalLink';
 const Speaker = () => {
-  const avatar = '/img/PNG/SpeakerWhite.png';
   return (
     <article className="SpeakerPagePlaceholder">
       <figure className="SpeakerPagePlaceholder__photo">
-        <img
-          className="SpeakerPagePlaceholder__photo--img"
-          src={avatar}
-          alt={'Speaker placeholder'}
-        />
       </figure>
       <div className="SpeakerPagePlaceholder__info">
-        <h5 className="SpeakerPagePlaceholder__text">Could this be you?</h5>
-        <ExternalLink
-          href="https://www.papercall.io/reactlondon2017"
-          className="SpeakerPagePlaceholder__button"
-        >
-          Become a speaker
-        </ExternalLink>
+        <h5 className="SpeakerPagePlaceholder__text">More speakers to be announced soon.</h5>
       </div>
     </article>
   );

--- a/shared/components/SpeakerPagePlaceholder/index.scss
+++ b/shared/components/SpeakerPagePlaceholder/index.scss
@@ -2,7 +2,7 @@
 
   display: flex;
   width: 100%;
-  margin-top: 45px;
+  margin-top: 30px;
 
   &__text{
     padding: 0px;
@@ -36,18 +36,8 @@
 
   &__photo {
     min-width: 120px;
-    min-height: 120px;
     width: 120px;
-    height: 120px;
     margin: 0px;
-    overflow: hidden;
-    border: $solid-border;
-    border-radius: 50%;
-    text-align: center;
-    &--svg, &--img {
-      height: 100%;
-      width: 100%;
-    }
   }
 }
 
@@ -58,7 +48,6 @@
     &__info {
       width: 100%;
       margin-left: 0;
-      margin-top: 20px;
     }
   }
 }

--- a/shared/components/SpeakerPlaceholder/index.js
+++ b/shared/components/SpeakerPlaceholder/index.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { ExternalLink } from '../ExternalLink';
 const Speaker = () => {
   const avatar = '/img/PNG/SpeakerWhite.png';
   return (
@@ -8,14 +7,8 @@ const Speaker = () => {
         <img className="Speaker__photo--img" src={avatar} alt={'Speaker placeholder'} />
       </figure>
       <h5 className="Speaker__name">
-        <div className="Speaker__name--bold__placeholder">Could this be you?</div>
+        <div className="Speaker__name--bold__placeholder">More speakers to be announced soon.</div>
       </h5>
-      <ExternalLink
-        href="https://www.papercall.io/reactlondon2017"
-        className="Speaker__button"
-      >
-        Become a speaker
-      </ExternalLink>
     </article>
   );
 };


### PR DESCRIPTION
On the 31st January the Call For Papers and Become a Speaker become obsolete.
(In the CFP, the link to 'React meetup' behaves the same as the 'Find our more' link in the footer)
The implementation differs from the Zeplin designs slightly (the changes came about after discussions with sari)
* Call for Papers - Changed the button colours to make it look disabled
* Become a Speaker - Kept image on home page. Left aligned message with text, not image
