### PR TITLE
Reverting order of speakers and limiting no of speakers on homepage

### DIFF
--- a/server/conference-data/index.js
+++ b/server/conference-data/index.js
@@ -32,10 +32,15 @@ export default function communityData(state) {
   const { partners, tickets, talks, calendarURL } = state.event;
   const speakers = pickSpeakersFromTalks(talks);
 
+  // Note that this line also affects order of the original
+  // speakers list, which is exactly what we want
+  const featuredSpeakers = speakers.reverse().slice(0, 5);
+
   return {
     ...groupPartnersByLevel(partners || []),
     tickets,
     speakers,
+    featuredSpeakers,
     calendarURL,
     talks,
   };

--- a/shared/components/NextConferenceEvent/index.js
+++ b/shared/components/NextConferenceEvent/index.js
@@ -45,7 +45,7 @@ TicketStatus.propTypes = {
   tickets: PropTypes.arrayOf(PropTypes.shape(ticketType)),
 };
 
-const NextConferenceEvent = ({ calendarURL, speakers, tickets }) => (
+const NextConferenceEvent = ({ calendarURL, featuredSpeakers, tickets }) => (
   <section className="NextConferenceEvent block">
     <div className="content">
       <h2 className="NextConferenceEvent__header">
@@ -78,7 +78,7 @@ const NextConferenceEvent = ({ calendarURL, speakers, tickets }) => (
       </article>
       <div className="NextConferenceEvent__accomodation">
         <h2>On stage</h2>
-        <SpeakerList speakers={speakers} conference />
+        <SpeakerList speakers={featuredSpeakers} conference />
       </div>
       <div className="NextConferenceEvent__accomodation">
         <h2>Plan your visit</h2>
@@ -104,6 +104,6 @@ const NextConferenceEvent = ({ calendarURL, speakers, tickets }) => (
 
 NextConferenceEvent.propTypes = {
   calendarURL: PropTypes.string,
-  speakers: PropTypes.arrayOf(speakerType),
+  featuredSpeakers: PropTypes.arrayOf(speakerType),
 };
 export default NextConferenceEvent;


### PR DESCRIPTION
![giphy 14](https://cloud.githubusercontent.com/assets/487468/22597380/4bb73cee-ea27-11e6-83b0-36e66369ba1d.gif)

Fix for #319:

* Order of conference speakers is now reversed on both homepage and speakers page
* Homepage speakers list is limited to 5 + one placeholder item