### PR TITLE
Adding Twitter Ads tracking code

### DIFF
--- a/server/views/index.pug
+++ b/server/views/index.pug
@@ -28,6 +28,12 @@ html
     link(rel="icon" type="image/png" href="/img/favicons/favicon-16x16.png" sizes="16x16")
     link(rel="manifest" href="/img/favicons/manifest.json")
     link(rel="mask-icon" href="/img/favicons/safari-pinned-tab.svg" color="#c6dde7")
+    script.
+      !function(e,t,n,s,u,a){e.twq||(s=e.twq=function(){s.exe?s.exe.apply(s,arguments):s.queue.push(arguments);
+      },s.version='1.1',s.queue=[],u=t.createElement(n),u.async=!0,u.src='//static.ads-twitter.com/uwt.js',
+      a=t.getElementsByTagName(n)[0],a.parentNode.insertBefore(u,a))}(window,document,'script');
+      twq('init','nw6qq');
+      twq('track','PageView');
 
   body
     main(id="main")


### PR DESCRIPTION
![giphy 13](https://cloud.githubusercontent.com/assets/487468/22781551/e3089b1e-eeba-11e6-965d-2af5d1f4bac0.gif)

For better conversion tracking of Twitter ads.

## Testing

As you navigate the pages, @ngoepel should tell if Twitter received any data.

Check also in Chrome devtools that we're requesting Twitter script correctly and getting 200 OK response. Apparently this only can be verified once this is on live.