### PR TITLE
display career brief for an organisation instead of description

### DIFF
--- a/server/data/badger-brain.js
+++ b/server/data/badger-brain.js
@@ -80,6 +80,7 @@ query {
     partners {
       name
       description
+      careerBrief
       url
       imageURL
       level

--- a/shared/components/ConferenceJobs/index.js
+++ b/shared/components/ConferenceJobs/index.js
@@ -29,7 +29,7 @@ const ConferenceJobs = ({ gold, silver, bronze }) => (
 
     <JobsSection
       partners={gold || []}
-      displayDescription
+      displayCareerBrief
     />
 
     <JobsSection

--- a/shared/components/ConferenceJobs/index.js
+++ b/shared/components/ConferenceJobs/index.js
@@ -29,7 +29,7 @@ const ConferenceJobs = ({ gold, silver, bronze }) => (
 
     <JobsSection
       partners={gold || []}
-      displayCareerBrief
+      displayDescription
     />
 
     <JobsSection

--- a/shared/components/JobsSection/index.js
+++ b/shared/components/JobsSection/index.js
@@ -5,11 +5,11 @@ const defaultImage = '/img/PNG/partner.png';
 
 const isEmpty = array => !Array.isArray(array) || array.length === 0;
 
-const Job = ({ title, location, description, displayDescription, jobURL }) => (
+const Job = ({ title, location, description, displayCareerBrief, jobURL }) => (
   <div className="Job">
     <h4 className="Job__title">{title}</h4>
     <p className="Job__location">{location}</p>
-    {displayDescription && <p className="Job__description">{description}</p>}
+    {displayCareerBrief && <p className="Job__description">{description}</p>}
     {jobURL && <a className="Job__link" href={jobURL} target="_blank" rel="noopener">Read more</a>}
   </div>
 );
@@ -17,12 +17,12 @@ const Job = ({ title, location, description, displayDescription, jobURL }) => (
 Job.propTypes = {
   title: PropTypes.string,
   location: PropTypes.string,
-  description: PropTypes.string,
-  displayDescription: PropTypes.bool,
+  careerBrief: PropTypes.string,
+  displayCareerBrief: PropTypes.bool,
   jobURL: PropTypes.string,
 };
 
-const JobPartner = ({ name, description, imageURL, partnerURL, displayDescription, jobs }) => {
+const JobPartner = ({ name, careerBrief, imageURL, partnerURL, displayCareerBrief, jobs }) => {
   if (isEmpty(jobs)) { return null; }
   return (
     <div className="content JobPartner">
@@ -33,9 +33,9 @@ const JobPartner = ({ name, description, imageURL, partnerURL, displayDescriptio
         <h4 className="JobPartner__title">{name}</h4>
       </div>
       <article className="JobPartner__details">
-        <p className="JobPartner__description">{description}</p>
+        <p className="JobPartner__description">{careerBrief}</p>
         {jobs.map((job, index) =>
-          <Job key={index} {...job} displayDescription={displayDescription} />)}
+          <Job key={index} {...job} displayCareerBrief={displayCareerBrief} />)}
       </article>
     </div>
   );
@@ -43,22 +43,22 @@ const JobPartner = ({ name, description, imageURL, partnerURL, displayDescriptio
 
 JobPartner.propTypes = {
   ...partnerType,
-  displayDescription: PropTypes.bool,
+  displayCareerBrief: PropTypes.bool,
 };
 
-const JobsSection = ({ partners, displayDescription }) => {
+const JobsSection = ({ partners, displayCareerBrief }) => {
   if (isEmpty(partners)) { return null; }
   return (
     <section className={'block JobsSection'}>
       {partners.map((partner, index) =>
-        <JobPartner key={index} {...partner} displayDescription={displayDescription} />)}
+        <JobPartner key={index} {...partner} displayCareerBrief={displayCareerBrief} />)}
     </section>
   );
 };
 
 JobsSection.propTypes = {
   partners: PropTypes.arrayOf(PropTypes.shape(partnerType)),
-  displayDescription: PropTypes.bool,
+  displayCareerBrief: PropTypes.bool,
 };
 
 export default JobsSection;

--- a/shared/components/JobsSection/index.js
+++ b/shared/components/JobsSection/index.js
@@ -5,11 +5,11 @@ const defaultImage = '/img/PNG/partner.png';
 
 const isEmpty = array => !Array.isArray(array) || array.length === 0;
 
-const Job = ({ title, location, description, displayCareerBrief, jobURL }) => (
+const Job = ({ title, location, description, displayDescription, jobURL }) => (
   <div className="Job">
     <h4 className="Job__title">{title}</h4>
     <p className="Job__location">{location}</p>
-    {displayCareerBrief && <p className="Job__description">{description}</p>}
+    {displayDescription && <p className="Job__description">{description}</p>}
     {jobURL && <a className="Job__link" href={jobURL} target="_blank" rel="noopener">Read more</a>}
   </div>
 );
@@ -18,11 +18,11 @@ Job.propTypes = {
   title: PropTypes.string,
   location: PropTypes.string,
   careerBrief: PropTypes.string,
-  displayCareerBrief: PropTypes.bool,
+  displayDescription: PropTypes.bool,
   jobURL: PropTypes.string,
 };
 
-const JobPartner = ({ name, careerBrief, imageURL, partnerURL, displayCareerBrief, jobs }) => {
+const JobPartner = ({ name, careerBrief, imageURL, partnerURL, displayDescription, jobs }) => {
   if (isEmpty(jobs)) { return null; }
   return (
     <div className="content JobPartner">
@@ -35,7 +35,7 @@ const JobPartner = ({ name, careerBrief, imageURL, partnerURL, displayCareerBrie
       <article className="JobPartner__details">
         <p className="JobPartner__description">{careerBrief}</p>
         {jobs.map((job, index) =>
-          <Job key={index} {...job} displayCareerBrief={displayCareerBrief} />)}
+          <Job key={index} {...job} displayDescription={displayDescription} />)}
       </article>
     </div>
   );
@@ -43,22 +43,22 @@ const JobPartner = ({ name, careerBrief, imageURL, partnerURL, displayCareerBrie
 
 JobPartner.propTypes = {
   ...partnerType,
-  displayCareerBrief: PropTypes.bool,
+  displayDescription: PropTypes.bool,
 };
 
-const JobsSection = ({ partners, displayCareerBrief }) => {
+const JobsSection = ({ partners, displayDescription }) => {
   if (isEmpty(partners)) { return null; }
   return (
     <section className={'block JobsSection'}>
       {partners.map((partner, index) =>
-        <JobPartner key={index} {...partner} displayCareerBrief={displayCareerBrief} />)}
+        <JobPartner key={index} {...partner} displayDescription={displayDescription} />)}
     </section>
   );
 };
 
 JobsSection.propTypes = {
   partners: PropTypes.arrayOf(PropTypes.shape(partnerType)),
-  displayCareerBrief: PropTypes.bool,
+  displayDescription: PropTypes.bool,
 };
 
 export default JobsSection;


### PR DESCRIPTION
* replaced organisation description in the jobs section to career brief defined in prismic

**Important** `badger-brain` [PR](https://github.com/redbadger/badger-brain/pull/101) should go first

