### PR TITLE
Set width for svg object for Firefox. Fixes #317

### DIFF
--- a/shared/components/Hero/index.scss
+++ b/shared/components/Hero/index.scss
@@ -35,9 +35,13 @@
     top: 198px;
     font-size: 16px
   }
+
+  object {
+    min-width: 1920px;
+    width: 100%;
+    height: 260px;
+  }
 }
-
-
 
 .Hero--Conference {
   background-color: $conference-color;


### PR DESCRIPTION
![alt](https://media.giphy.com/media/ZXMwuyiiMBX8c/giphy.gif)