### PR TITLE
make-circle-ci-green-again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,4 +94,3 @@ workflows:
             branches:
               only:
                 - master
-                - bugfix/ci-issues

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,7 @@
-version: 2
+version: 2.1
+orbs:
+  aws-ecr: circleci/aws-ecr@6.7.0
+  aws-cli: circleci/aws-cli@1.2.1
 jobs:
   build:
     working_directory: ~/redbadger/react.london
@@ -10,19 +13,11 @@ jobs:
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
 
     docker:
-      - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
-        command: /sbin/init
+      - image: circleci/node:8.15
     steps:
       - checkout
 
       - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
-
-      - run:
-          working_directory: ~/redbadger/react.london
-          command: nvm install 8.15.0 && nvm alias default 8.15.0
-      - run:
-          working_directory: ~/redbadger/react.london
-          command: "sudo docker info >/dev/null 2>&1 || sudo service docker start; "
 
       - restore_cache:
           keys:
@@ -62,13 +57,13 @@ jobs:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
 
-    docker:
-      - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
-        command: /sbin/init
+    executor: aws-cli/default
 
     steps:
       - checkout
-      - setup_remote_docker
+      - aws-cli/setup: {
+        configure-default-region: FALSE
+      }
       - run: ./bin/push-new-version.sh
       - run: ./bin/deploy-version.js staging
       - run: ./bin/notify-slack.sh '[CircleCi] Deploying React.London master to staging.'
@@ -78,9 +73,25 @@ workflows:
   build_and_deploy:
     jobs:
       - build
+      - aws-ecr/build-and-push-image:
+          requires:
+            - build
+          account-url: AWS_ECR_ACCOUNT_URL_ENV_VAR_NAME
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+          create-repo: false
+          dockerfile: Dockerfile
+          path: .
+          region: AWS_REGION
+          tag: "$(git rev-parse --abbrev-ref HEAD | sed 's/[^a-zA-Z_-]/-/g')-$(git rev-parse HEAD)"
+          repo: react-london
+          extra-build-args: "--build-arg GIT_COMMIT=$CIRCLE_SHA1"
       - deploy_to_staging:
           requires:
             - build
+            - aws-ecr/build-and-push-image
           filters:
             branches:
-              only: master
+              only:
+                - master
+                - bugfix/ci-issues

--- a/bin/push-new-version.sh
+++ b/bin/push-new-version.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 VERSION=$(git rev-parse HEAD)
 BRANCH=$(git rev-parse --abbrev-ref HEAD | sed 's/[^a-zA-Z_-]/-/g')
 TAG=$BRANCH-$VERSION
@@ -18,15 +17,6 @@ echo Creating new application version $TAG
 # Requires these env vars set on CI:
 #   - AWS_ACCESS_KEY_ID
 #   - AWS_SECRET_ACCESS_KEY
-echo Authenticating.
-eval $(aws ecr get-login --region=$AWS_REGION | sed 's|https://||')
-
-echo Building docker image
-docker build -t $APP_NAME --build-arg GIT_COMMIT=$(git rev-parse --short HEAD) .
-docker tag $APP_NAME $ECR_REPO:$TAG
-
-echo Pushing docker image
-docker push $ECR_REPO:$TAG
 
 echo Creating new EB version zip
 cp Dockerrun.aws.json.template Dockerrun.aws.json


### PR DESCRIPTION
Make circle ci green again
==
![](https://media.giphy.com/media/JJhiRdcYfcokU/giphy.gif
)

### What was the issue?
All builds were failing due to a change to the underlying circle ubuntu image. Read this [thread](https://discuss.circleci.com/t/circleci-was-unable-to-run-the-job-runner/31894/17) on the circle forums if you would like context on what was happening.

### What has changed?
After investigating with @kephail we changed the underlying base image which was over 2 years old to use the circle ci node image. This then led some `sudo` commands starting `docker service` to stop working. After some further investigation, I realized that docker was already available on the image so I removed these commands.  

Now the build was passing but the push and deploy script that pushes to Amazons Elastic Container Registry was not authenticating properly and so was not able to push. I suspect that this is due to the way circle ci 2.1 runs docker commands in a remote separate environment for security reasons. I looked at some examples of communicating between AWS and circle and it seemed like the recommended way to do this was to use orbs (which are like functions for ci). 

Using the orb for `aws/ecr` and for `aws/cli` I was able to get the deploy and push scripts working again. This did mean I had to change the structure of the `circle.yml` and the shell script for pushing and deploying images. 

### How can we test it?
[x] circle ci passes
[] make sure staging works 
 